### PR TITLE
Fix version range to work with dotnet-sdk 3.1.107

### DIFF
--- a/Jellyfin.Plugin.PlaybackReporting/Jellyfin.Plugin.PlaybackReporting.csproj
+++ b/Jellyfin.Plugin.PlaybackReporting/Jellyfin.Plugin.PlaybackReporting.csproj
@@ -43,8 +43,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Jellyfin.Data" Version="10.*-*"/>
-    <PackageReference Include="Jellyfin.Controller" Version="10.*-*" />
+    <PackageReference Include="Jellyfin.Data" Version="10.*"/>
+    <PackageReference Include="Jellyfin.Controller" Version="10.*" />
     <PackageReference Include="SQLitePCL.pretty.netstandard" Version="1.0.0" />
     <PackageReference Include="System.Memory" Version="4.5.*" />
   </ItemGroup>


### PR DESCRIPTION
Without this change, building/restoring on Linux with dotnet-sdk 3.1.107 fails with the following:

```
/usr/share/dotnet/sdk/3.1.107/NuGet.targets(123,5): error : '10.*-*' is not a valid version string. [/home/legogris/dev/jellyfin-plugin-playbackreporting/Jellyfin.Plugin.PlaybackReporting/Jellyfin.Plugin.PlaybackR
eporting.csproj]
```

This fixes that.