### PR TITLE
Fix tabs rendering

### DIFF
--- a/Jellyfin.Plugin.PlaybackReporting/Pages/breakdown_report.js
+++ b/Jellyfin.Plugin.PlaybackReporting/Pages/breakdown_report.js
@@ -251,7 +251,7 @@ define(['libraryMenu'], function (libraryMenu) {
         // init code here
         view.addEventListener('viewshow', function (e) {
 
-            libraryMenu.setTabs('playback_reporting', 2, getTabs);
+            LibraryMenu.setTabs('playback_reporting', 2, getTabs);
 
             require([Dashboard.getConfigurationResourceUrl('Chart.bundle.min.js')], function (d3) {
 

--- a/Jellyfin.Plugin.PlaybackReporting/Pages/custom_query.js
+++ b/Jellyfin.Plugin.PlaybackReporting/Pages/custom_query.js
@@ -69,7 +69,7 @@ define(['libraryMenu'], function (libraryMenu) {
         // init code here
         view.addEventListener('viewshow', function (e) {
 
-            libraryMenu.setTabs('custom_query', 5, getTabs);
+            LibraryMenu.setTabs('custom_query', 5, getTabs);
 
             var run_custom_query = view.querySelector('#run_custom_query');
             run_custom_query.addEventListener("click", runQuery);

--- a/Jellyfin.Plugin.PlaybackReporting/Pages/duration_histogram_report.js
+++ b/Jellyfin.Plugin.PlaybackReporting/Pages/duration_histogram_report.js
@@ -157,7 +157,7 @@ define(['libraryMenu'], function (libraryMenu) {
         // init code here
         view.addEventListener('viewshow', function (e) {
 
-            libraryMenu.setTabs('Jellyfin.Plugin.PlaybackReporting', 4, getTabs);
+            LibraryMenu.setTabs('Jellyfin.Plugin.PlaybackReporting', 4, getTabs);
 
             require([Dashboard.getConfigurationResourceUrl('Chart.bundle.min.js')], function (d3) {
 

--- a/Jellyfin.Plugin.PlaybackReporting/Pages/hourly_usage_report.js
+++ b/Jellyfin.Plugin.PlaybackReporting/Pages/hourly_usage_report.js
@@ -359,7 +359,7 @@ define(['libraryMenu'], function (libraryMenu) {
         // init code here
         view.addEventListener('viewshow', function (e) {
 
-            libraryMenu.setTabs('playback_reporting', 3, getTabs);
+            LibraryMenu.setTabs('playback_reporting', 3, getTabs);
 
             require([Dashboard.getConfigurationResourceUrl('Chart.bundle.min.js')], function (d3) {
 

--- a/Jellyfin.Plugin.PlaybackReporting/Pages/playback_report_settings.js
+++ b/Jellyfin.Plugin.PlaybackReporting/Pages/playback_report_settings.js
@@ -145,7 +145,7 @@ define(['libraryMenu'], function (libraryMenu) {
         // init code here
         view.addEventListener('viewshow', function (e) {
 
-            libraryMenu.setTabs('playplayback_report_settingsback_reporting', 6, getTabs);
+            LibraryMenu.setTabs('playplayback_report_settingsback_reporting', 6, getTabs);
 
             var set_backup_path = view.querySelector('#set_backup_path');
             set_backup_path.addEventListener("click", setBackupPathPicker);

--- a/Jellyfin.Plugin.PlaybackReporting/Pages/user_playback_report.js
+++ b/Jellyfin.Plugin.PlaybackReporting/Pages/user_playback_report.js
@@ -451,7 +451,7 @@ define(['libraryMenu'], function (libraryMenu) {
         // https://cdnjs.cloudflare.com/ajax/libs/Chart.js/2.7.2/Chart.bundle.min.js
         view.addEventListener('viewshow', function (e) {
 
-            libraryMenu.setTabs('playback_reporting', 1, getTabs);
+            LibraryMenu.setTabs('playback_reporting', 1, getTabs);
 
             require([Dashboard.getConfigurationResourceUrl('Chart.bundle.min.js')], function (d3) {
 

--- a/Jellyfin.Plugin.PlaybackReporting/Pages/user_report.js
+++ b/Jellyfin.Plugin.PlaybackReporting/Pages/user_report.js
@@ -70,7 +70,7 @@ define(['libraryMenu'], function (libraryMenu) {
         // init code here
         view.addEventListener('viewshow', function (e) {
 
-            libraryMenu.setTabs('user_report', 0, getTabs);
+            LibraryMenu.setTabs('user_report', 0, getTabs);
 
             var end_date = view.querySelector('#end_date');
             end_date.value = new Date().toDateInputValue();


### PR DESCRIPTION
This plugin has been working OK pre-10.6. In latest `jellyfin-web`, the settings page errors with `libraryMenu.setTabs is not a function`. Using the global `LibraryMenu` instead fixes that.