### PR TITLE
ES6 - Make plugin compatible with ES6

### DIFF
--- a/Jellyfin.Plugin.PlaybackReporting/Pages/breakdown_report.js
+++ b/Jellyfin.Plugin.PlaybackReporting/Pages/breakdown_report.js
@@ -254,8 +254,11 @@ const getConfigurationPageUrl = (name) => {
 
             LibraryMenu.setTabs('playback_reporting', 2, getTabs);
 
-            import('./Chart.bundle.min.js').then(({default: d3}) => {
-
+            import(
+                window.ApiClient.getUrl("web/ConfigurationPage", {
+                  name: "Chart.bundle.min.js",
+                })
+            ).then(({default: d3}) => {
                 var end_date = view.querySelector('#end_date');
                 end_date.value = new Date().toDateInputValue();
                 end_date.addEventListener("change", process_click);

--- a/Jellyfin.Plugin.PlaybackReporting/Pages/breakdown_report.js
+++ b/Jellyfin.Plugin.PlaybackReporting/Pages/breakdown_report.js
@@ -14,8 +14,9 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see<http://www.gnu.org/licenses/>.
 */
 
-define(['libraryMenu'], function (libraryMenu) {
-    'use strict';
+const getConfigurationPageUrl = (name) => {
+    return 'configurationpage?name=' + encodeURIComponent(name);
+}
 
     var chart_instance_map = {};
 
@@ -216,37 +217,37 @@ define(['libraryMenu'], function (libraryMenu) {
     function getTabs() {
         var tabs = [
             {
-                href: Dashboard.getConfigurationPageUrl('user_report'),
+                href: getConfigurationPageUrl('user_report'),
                 name: 'Users'
             },
             {
-                href: Dashboard.getConfigurationPageUrl('user_playback_report'),
+                href: getConfigurationPageUrl('user_playback_report'),
                 name: 'Playback'
             },
             {
-                href: Dashboard.getConfigurationPageUrl('breakdown_report'),
+                href: getConfigurationPageUrl('breakdown_report'),
                 name: 'Breakdown'
             },
             {
-                href: Dashboard.getConfigurationPageUrl('hourly_usage_report'),
+                href: getConfigurationPageUrl('hourly_usage_report'),
                 name: 'Usage'
             },
             {
-                href: Dashboard.getConfigurationPageUrl('duration_histogram_report'),
+                href: getConfigurationPageUrl('duration_histogram_report'),
                 name: 'Duration'
             },
             {
-                href: Dashboard.getConfigurationPageUrl('custom_query'),
+                href: getConfigurationPageUrl('custom_query'),
                 name: 'Query'
             },
             {
-                href: Dashboard.getConfigurationPageUrl('playback_report_settings'),
+                href: getConfigurationPageUrl('playback_report_settings'),
                 name: 'Settings'
             }];
         return tabs;
     }
 
-    return function (view, params) {
+    export default function (view, params) {
 
         // init code here
         view.addEventListener('viewshow', function (e) {
@@ -337,4 +338,4 @@ define(['libraryMenu'], function (libraryMenu) {
 
         });
     };
-});
+

--- a/Jellyfin.Plugin.PlaybackReporting/Pages/breakdown_report.js
+++ b/Jellyfin.Plugin.PlaybackReporting/Pages/breakdown_report.js
@@ -20,7 +20,7 @@ const getConfigurationPageUrl = (name) => {
 
     var chart_instance_map = {};
 
-    ApiClient.getUserActivity = function (url_to_get) {
+    window.ApiClient.getUserActivity = function (url_to_get) {
         console.log("getUserActivity Url = " + url_to_get);
         return this.ajax({
             type: "GET",
@@ -254,7 +254,7 @@ const getConfigurationPageUrl = (name) => {
 
             LibraryMenu.setTabs('playback_reporting', 2, getTabs);
 
-            require([Dashboard.getConfigurationResourceUrl('Chart.bundle.min.js')], function (d3) {
+            import('./Chart.bundle.min.js').then(({default: d3}) => {
 
                 var end_date = view.querySelector('#end_date');
                 end_date.value = new Date().toDateInputValue();
@@ -273,56 +273,56 @@ const getConfigurationPageUrl = (name) => {
                     
                     // build user chart
                     var url = "user_usage_stats/UserId/BreakdownReport?days=" + days + "&end_date=" + end_date.value + "&stamp=" + new Date().getTime();
-                    url = ApiClient.getUrl(url);
-                    ApiClient.getUserActivity(url).then(function (data) {
+                    url = window.ApiClient.getUrl(url);
+                    window.ApiClient.getUserActivity(url).then(function (data) {
                         //alert("Loaded Data: " + JSON.stringify(usage_data));
                         draw_chart_user_count(view, d3, data, "User");
                     });
 
                     // build ItemType chart
                     var url = "user_usage_stats/ItemType/BreakdownReport?days=" + days + "&end_date=" + end_date.value + "&stamp=" + new Date().getTime();
-                    url = ApiClient.getUrl(url);
-                    ApiClient.getUserActivity(url).then(function (data) {
+                    url = window.ApiClient.getUrl(url);
+                    window.ApiClient.getUserActivity(url).then(function (data) {
                         //alert("Loaded Data: " + JSON.stringify(usage_data));
                         draw_chart_user_count(view, d3, data, "ItemType");
                     });
 
                     // build PlaybackMethod chart
                     var url = "user_usage_stats/PlaybackMethod/BreakdownReport?days=" + days + "&end_date=" + end_date.value + "&stamp=" + new Date().getTime();
-                    url = ApiClient.getUrl(url);
-                    ApiClient.getUserActivity(url).then(function (data) {
+                    url = window.ApiClient.getUrl(url);
+                    window.ApiClient.getUserActivity(url).then(function (data) {
                         //alert("Loaded Data: " + JSON.stringify(usage_data));
                         draw_chart_user_count(view, d3, data, "PlayMethod");
                     });
 
                     // build ClientName chart
                     var url = "user_usage_stats/ClientName/BreakdownReport?days=" + days + "&end_date=" + end_date.value + "&stamp=" + new Date().getTime();
-                    url = ApiClient.getUrl(url);
-                    ApiClient.getUserActivity(url).then(function (data) {
+                    url = window.ApiClient.getUrl(url);
+                    window.ApiClient.getUserActivity(url).then(function (data) {
                         //alert("Loaded Data: " + JSON.stringify(usage_data));
                         draw_chart_user_count(view, d3, data, "ClientName");
                     });
 
                     // build DeviceName chart
                     var url = "user_usage_stats/DeviceName/BreakdownReport?days=" + days + "&end_date=" + end_date.value + "&stamp=" + new Date().getTime();
-                    url = ApiClient.getUrl(url);
-                    ApiClient.getUserActivity(url).then(function (data) {
+                    url = window.ApiClient.getUrl(url);
+                    window.ApiClient.getUserActivity(url).then(function (data) {
                         //alert("Loaded Data: " + JSON.stringify(usage_data));
                         draw_chart_user_count(view, d3, data, "DeviceName");
                     });
 
                     // build TvShows chart
                     var url = "user_usage_stats/TvShowsReport?days=" + days + "&end_date=" + end_date.value + "&stamp=" + new Date().getTime();
-                    url = ApiClient.getUrl(url);
-                    ApiClient.getUserActivity(url).then(function (data) {
+                    url = window.ApiClient.getUrl(url);
+                    window.ApiClient.getUserActivity(url).then(function (data) {
                         //alert("Loaded Data: " + JSON.stringify(usage_data));
                         draw_chart_user_count(view, d3, data, "TvShows");
                     });
 
                     // build Movies chart
                     var url = "user_usage_stats/MoviesReport?days=" + days + "&end_date=" + end_date.value + "&stamp=" + new Date().getTime();
-                    url = ApiClient.getUrl(url);
-                    ApiClient.getUserActivity(url).then(function (data) {
+                    url = window.ApiClient.getUrl(url);
+                    window.ApiClient.getUserActivity(url).then(function (data) {
                         //alert("Loaded Data: " + JSON.stringify(usage_data));
                         draw_chart_user_count(view, d3, data, "Movies");
                     });

--- a/Jellyfin.Plugin.PlaybackReporting/Pages/custom_query.js
+++ b/Jellyfin.Plugin.PlaybackReporting/Pages/custom_query.js
@@ -14,9 +14,9 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see<http://www.gnu.org/licenses/>.
 */
 
-define(['libraryMenu'], function (libraryMenu) {
-    'use strict';
-
+const getConfigurationPageUrl = (name) => {
+    return 'configurationpage?name=' + encodeURIComponent(name);
+}
 
     ApiClient.sendCustomQuery = function (url_to_get, query_data) {
         var post_data = JSON.stringify(query_data);
@@ -34,37 +34,37 @@ define(['libraryMenu'], function (libraryMenu) {
     function getTabs() {
         var tabs = [
             {
-                href: Dashboard.getConfigurationPageUrl('user_report'),
+                href: getConfigurationPageUrl('user_report'),
                 name: 'Users'
             },
             {
-                href: Dashboard.getConfigurationPageUrl('user_playback_report'),
+                href: getConfigurationPageUrl('user_playback_report'),
                 name: 'Playback'
             },
             {
-                href: Dashboard.getConfigurationPageUrl('breakdown_report'),
+                href: getConfigurationPageUrl('breakdown_report'),
                 name: 'Breakdown'
             },
             {
-                href: Dashboard.getConfigurationPageUrl('hourly_usage_report'),
+                href: getConfigurationPageUrl('hourly_usage_report'),
                 name: 'Usage'
             },
             {
-                href: Dashboard.getConfigurationPageUrl('duration_histogram_report'),
+                href: getConfigurationPageUrl('duration_histogram_report'),
                 name: 'Duration'
             },
             {
-                href: Dashboard.getConfigurationPageUrl('custom_query'),
+                href: getConfigurationPageUrl('custom_query'),
                 name: 'Query'
             },
             {
-                href: Dashboard.getConfigurationPageUrl('playback_report_settings'),
+                href: getConfigurationPageUrl('playback_report_settings'),
                 name: 'Settings'
             }];
         return tabs;
     }
 
-    return function (view, params) {
+    export default function (view, params) {
 
         // init code here
         view.addEventListener('viewshow', function (e) {
@@ -151,4 +151,3 @@ define(['libraryMenu'], function (libraryMenu) {
 
         });
     };
-});

--- a/Jellyfin.Plugin.PlaybackReporting/Pages/custom_query.js
+++ b/Jellyfin.Plugin.PlaybackReporting/Pages/custom_query.js
@@ -18,7 +18,7 @@ const getConfigurationPageUrl = (name) => {
     return 'configurationpage?name=' + encodeURIComponent(name);
 }
 
-    ApiClient.sendCustomQuery = function (url_to_get, query_data) {
+    window.ApiClient.sendCustomQuery = function (url_to_get, query_data) {
         var post_data = JSON.stringify(query_data);
         console.log("sendCustomQuery url  = " + url_to_get);
         console.log("sendCustomQuery data = " + post_data);
@@ -87,14 +87,14 @@ const getConfigurationPageUrl = (name) => {
                 table_body.innerHTML = "";
 
                 var url = "user_usage_stats/submit_custom_query?stamp=" + new Date().getTime();
-                url = ApiClient.getUrl(url);
+                url = window.ApiClient.getUrl(url);
 
                 var query_data = {
                     CustomQueryString: custom_query.value,
                     ReplaceUserId: replace_userid
                 };
 
-                ApiClient.sendCustomQuery(url, query_data).then(function (result) {
+                window.ApiClient.sendCustomQuery(url, query_data).then(function (result) {
                     //alert("Loaded Data: " + JSON.stringify(result));
 
                     var message = result["message"];

--- a/Jellyfin.Plugin.PlaybackReporting/Pages/duration_histogram_report.js
+++ b/Jellyfin.Plugin.PlaybackReporting/Pages/duration_histogram_report.js
@@ -14,8 +14,9 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see<http://www.gnu.org/licenses/>.
 */
 
-define(['libraryMenu'], function (libraryMenu) {
-    'use strict';
+const getConfigurationPageUrl = (name) => {
+    return 'configurationpage?name=' + encodeURIComponent(name);
+}
 
     var my_bar_chart = null;
     var filter_names = [];
@@ -122,37 +123,37 @@ define(['libraryMenu'], function (libraryMenu) {
     function getTabs() {
         var tabs = [
             {
-                href: Dashboard.getConfigurationPageUrl('user_report'),
+                href: getConfigurationPageUrl('user_report'),
                 name: 'Users'
             },
             {
-                href: Dashboard.getConfigurationPageUrl('user_playback_report'),
+                href: getConfigurationPageUrl('user_playback_report'),
                 name: 'Playback'
             },
             {
-                href: Dashboard.getConfigurationPageUrl('breakdown_report'),
+                href: getConfigurationPageUrl('breakdown_report'),
                 name: 'Breakdown'
             },
             {
-                href: Dashboard.getConfigurationPageUrl('hourly_usage_report'),
+                href: getConfigurationPageUrl('hourly_usage_report'),
                 name: 'Usage'
             },
             {
-                href: Dashboard.getConfigurationPageUrl('duration_histogram_report'),
+                href: getConfigurationPageUrl('duration_histogram_report'),
                 name: 'Duration'
             },
             {
-                href: Dashboard.getConfigurationPageUrl('custom_query'),
+                href: getConfigurationPageUrl('custom_query'),
                 name: 'Query'
             },
             {
-                href: Dashboard.getConfigurationPageUrl('playback_report_settings'),
+                href: getConfigurationPageUrl('playback_report_settings'),
                 name: 'Settings'
             }];
         return tabs;
     }
 
-    return function (view, params) {
+    export default function (view, params) {
 
         // init code here
         view.addEventListener('viewshow', function (e) {
@@ -227,4 +228,3 @@ define(['libraryMenu'], function (libraryMenu) {
 
         });
     };
-});

--- a/Jellyfin.Plugin.PlaybackReporting/Pages/duration_histogram_report.js
+++ b/Jellyfin.Plugin.PlaybackReporting/Pages/duration_histogram_report.js
@@ -27,7 +27,7 @@ const getConfigurationPageUrl = (name) => {
         return local.toJSON().slice(0, 10);
     });
 
-    ApiClient.getUserActivity = function (url_to_get) {
+    window.ApiClient.getUserActivity = function (url_to_get) {
         console.log("getUserActivity Url = " + url_to_get);
         return this.ajax({
             type: "GET",
@@ -160,12 +160,12 @@ const getConfigurationPageUrl = (name) => {
 
             LibraryMenu.setTabs('Jellyfin.Plugin.PlaybackReporting', 4, getTabs);
 
-            require([Dashboard.getConfigurationResourceUrl('Chart.bundle.min.js')], function (d3) {
+            import('./Chart.bundle.min.js').then(({default: d3}) => {
 
                 // get filter types form sever
-                var filter_url = ApiClient.getUrl("user_usage_stats/type_filter_list");
+                var filter_url = window.ApiClient.getUrl("user_usage_stats/type_filter_list");
                 console.log("loading types form : " + filter_url);
-                ApiClient.getUserActivity(filter_url).then(function (filter_data) {
+                window.ApiClient.getUserActivity(filter_url).then(function (filter_data) {
                     filter_names = filter_data;
                     
                     // build filter list
@@ -207,8 +207,8 @@ const getConfigurationPageUrl = (name) => {
                         if (days == -7) days = 18250;
 
                         var url = "user_usage_stats/DurationHistogramReport?days=" + days + "&end_date=" + end_date.value + "&filter=" + filter.join(",") + "&stamp=" + new Date().getTime();
-                        url = ApiClient.getUrl(url);
-                        ApiClient.getUserActivity(url).then(function (usage_data) {
+                        url = window.ApiClient.getUrl(url);
+                        window.ApiClient.getUserActivity(url).then(function (usage_data) {
                             //alert("Loaded Data: " + JSON.stringify(usage_data));
                             draw_graph(view, d3, usage_data);
                         });

--- a/Jellyfin.Plugin.PlaybackReporting/Pages/duration_histogram_report.js
+++ b/Jellyfin.Plugin.PlaybackReporting/Pages/duration_histogram_report.js
@@ -160,8 +160,11 @@ const getConfigurationPageUrl = (name) => {
 
             LibraryMenu.setTabs('Jellyfin.Plugin.PlaybackReporting', 4, getTabs);
 
-            import('./Chart.bundle.min.js').then(({default: d3}) => {
-
+            import(
+                window.ApiClient.getUrl("web/ConfigurationPage", {
+                  name: "Chart.bundle.min.js",
+                })
+            ).then(({default: d3}) => {
                 // get filter types form sever
                 var filter_url = window.ApiClient.getUrl("user_usage_stats/type_filter_list");
                 console.log("loading types form : " + filter_url);

--- a/Jellyfin.Plugin.PlaybackReporting/Pages/hourly_usage_report.js
+++ b/Jellyfin.Plugin.PlaybackReporting/Pages/hourly_usage_report.js
@@ -362,7 +362,11 @@ const getConfigurationPageUrl = (name) => {
 
             LibraryMenu.setTabs('playback_reporting', 3, getTabs);
 
-            import('./Chart.bundle.min.js').then(({default: d3}) => {
+            import(
+                window.ApiClient.getUrl("web/ConfigurationPage", {
+                  name: "Chart.bundle.min.js",
+                })
+            ).then(({default: d3}) => {
 
                 var filter_url = window.ApiClient.getUrl("user_usage_stats/type_filter_list");
                 console.log("loading types form : " + filter_url);

--- a/Jellyfin.Plugin.PlaybackReporting/Pages/hourly_usage_report.js
+++ b/Jellyfin.Plugin.PlaybackReporting/Pages/hourly_usage_report.js
@@ -1,4 +1,4 @@
-﻿/*
+/*
 Copyright(C) 2018
 
 This program is free software: you can redistribute it and/or modify
@@ -29,7 +29,7 @@ const getConfigurationPageUrl = (name) => {
         return local.toJSON().slice(0, 10);
     });
 
-    ApiClient.getUserActivity = function (url_to_get) {
+    window.ApiClient.getUserActivity = function (url_to_get) {
         console.log("getUserActivity Url = " + url_to_get);
         return this.ajax({
             type: "GET",
@@ -362,11 +362,11 @@ const getConfigurationPageUrl = (name) => {
 
             LibraryMenu.setTabs('playback_reporting', 3, getTabs);
 
-            require([Dashboard.getConfigurationResourceUrl('Chart.bundle.min.js')], function (d3) {
+            import('./Chart.bundle.min.js').then(({default: d3}) => {
 
-                var filter_url = ApiClient.getUrl("user_usage_stats/type_filter_list");
+                var filter_url = window.ApiClient.getUrl("user_usage_stats/type_filter_list");
                 console.log("loading types form : " + filter_url);
-                ApiClient.getUserActivity(filter_url).then(function (filter_data) {
+                window.ApiClient.getUserActivity(filter_url).then(function (filter_data) {
                     filter_names = filter_data;
 
                     // build filter list
@@ -408,8 +408,8 @@ const getConfigurationPageUrl = (name) => {
                         if (days == -7) days = 18250;
                         
                         var url = "user_usage_stats/HourlyReport?days=" + days + "&end_date=" + end_date.value + "&filter=" + filter.join(",") + "&stamp=" + new Date().getTime();
-                        url = ApiClient.getUrl(url);
-                        ApiClient.getUserActivity(url).then(function (usage_data) {
+                        url = window.ApiClient.getUrl(url);
+                        window.ApiClient.getUserActivity(url).then(function (usage_data) {
                             //alert("Loaded Data: " + JSON.stringify(usage_data));
                             draw_graph(view, d3, usage_data);
                         });

--- a/Jellyfin.Plugin.PlaybackReporting/Pages/hourly_usage_report.js
+++ b/Jellyfin.Plugin.PlaybackReporting/Pages/hourly_usage_report.js
@@ -14,8 +14,9 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see<http://www.gnu.org/licenses/>.
 */
 
-define(['libraryMenu'], function (libraryMenu) {
-    'use strict';
+const getConfigurationPageUrl = (name) => {
+    return 'configurationpage?name=' + encodeURIComponent(name);
+}
 
     var daily_bar_chart = null;
     var hourly_bar_chart = null;
@@ -324,37 +325,37 @@ define(['libraryMenu'], function (libraryMenu) {
     function getTabs() {
         var tabs = [
             {
-                href: Dashboard.getConfigurationPageUrl('user_report'),
+                href: getConfigurationPageUrl('user_report'),
                 name: 'Users'
             },
             {
-                href: Dashboard.getConfigurationPageUrl('user_playback_report'),
+                href: getConfigurationPageUrl('user_playback_report'),
                 name: 'Playback'
             },
             {
-                href: Dashboard.getConfigurationPageUrl('breakdown_report'),
+                href: getConfigurationPageUrl('breakdown_report'),
                 name: 'Breakdown'
             },
             {
-                href: Dashboard.getConfigurationPageUrl('hourly_usage_report'),
+                href: getConfigurationPageUrl('hourly_usage_report'),
                 name: 'Usage'
             },
             {
-                href: Dashboard.getConfigurationPageUrl('duration_histogram_report'),
+                href: getConfigurationPageUrl('duration_histogram_report'),
                 name: 'Duration'
             },
             {
-                href: Dashboard.getConfigurationPageUrl('custom_query'),
+                href: getConfigurationPageUrl('custom_query'),
                 name: 'Query'
             },
             {
-                href: Dashboard.getConfigurationPageUrl('playback_report_settings'),
+                href: getConfigurationPageUrl('playback_report_settings'),
                 name: 'Settings'
             }];
         return tabs;
     }
 
-    return function (view, params) {
+    export default function (view, params) {
 
         // init code here
         view.addEventListener('viewshow', function (e) {
@@ -426,4 +427,3 @@ define(['libraryMenu'], function (libraryMenu) {
 
         });
     };
-});

--- a/Jellyfin.Plugin.PlaybackReporting/Pages/playback_report_settings.js
+++ b/Jellyfin.Plugin.PlaybackReporting/Pages/playback_report_settings.js
@@ -14,8 +14,9 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see<http://www.gnu.org/licenses/>.
 */
 
-define(['libraryMenu'], function (libraryMenu) {
-    'use strict';
+const getConfigurationPageUrl = (name) => {
+    return 'configurationpage?name=' + encodeURIComponent(name);
+}
 
     ApiClient.getUserActivity = function (url_to_get) {
         console.log("getUserActivity Url = " + url_to_get);
@@ -53,31 +54,31 @@ define(['libraryMenu'], function (libraryMenu) {
     function getTabs() {
         var tabs = [
             {
-                href: Dashboard.getConfigurationPageUrl('user_report'),
+                href: getConfigurationPageUrl('user_report'),
                 name: 'Users'
             },
             {
-                href: Dashboard.getConfigurationPageUrl('user_playback_report'),
+                href: getConfigurationPageUrl('user_playback_report'),
                 name: 'Playback'
             },
             {
-                href: Dashboard.getConfigurationPageUrl('breakdown_report'),
+                href: getConfigurationPageUrl('breakdown_report'),
                 name: 'Breakdown'
             },
             {
-                href: Dashboard.getConfigurationPageUrl('hourly_usage_report'),
+                href: getConfigurationPageUrl('hourly_usage_report'),
                 name: 'Usage'
             },
             {
-                href: Dashboard.getConfigurationPageUrl('duration_histogram_report'),
+                href: getConfigurationPageUrl('duration_histogram_report'),
                 name: 'Duration'
             },
             {
-                href: Dashboard.getConfigurationPageUrl('custom_query'),
+                href: getConfigurationPageUrl('custom_query'),
                 name: 'Query'
             },
             {
-                href: Dashboard.getConfigurationPageUrl('playback_report_settings'),
+                href: getConfigurationPageUrl('playback_report_settings'),
                 name: 'Settings'
             }];
         return tabs;
@@ -140,7 +141,7 @@ define(['libraryMenu'], function (libraryMenu) {
         });
     }
 
-    return function (view, params) {
+    export default function (view, params) {
 
         // init code here
         view.addEventListener('viewshow', function (e) {
@@ -262,5 +263,3 @@ define(['libraryMenu'], function (libraryMenu) {
 
         });
     };
-});
-

--- a/Jellyfin.Plugin.PlaybackReporting/Pages/playback_report_settings.js
+++ b/Jellyfin.Plugin.PlaybackReporting/Pages/playback_report_settings.js
@@ -18,7 +18,7 @@ const getConfigurationPageUrl = (name) => {
     return 'configurationpage?name=' + encodeURIComponent(name);
 }
 
-    ApiClient.getUserActivity = function (url_to_get) {
+    window.ApiClient.getUserActivity = function (url_to_get) {
         console.log("getUserActivity Url = " + url_to_get);
         return this.ajax({
             type: "GET",
@@ -28,10 +28,10 @@ const getConfigurationPageUrl = (name) => {
     };	
 
     function setBackupPathCallBack(selectedDir, view) {
-        ApiClient.getNamedConfiguration('playback_reporting').then(function (config) {
+        window.ApiClient.getNamedConfiguration('playback_reporting').then(function (config) {
             config.BackupPath = selectedDir;
             console.log("New Config Settings : " + JSON.stringify(config));
-            ApiClient.updateNamedConfiguration('playback_reporting', config);
+            window.ApiClient.updateNamedConfiguration('playback_reporting', config);
 
             var backup_path_label = view.querySelector('#backup_path_label');
             backup_path_label.innerHTML = selectedDir;
@@ -52,6 +52,7 @@ const getConfigurationPageUrl = (name) => {
     }
 
     function getTabs() {
+        console.log(window)
         var tabs = [
             {
                 href: getConfigurationPageUrl('user_report'),
@@ -86,12 +87,12 @@ const getConfigurationPageUrl = (name) => {
 
     function saveBackup(view) {
         var url = "user_usage_stats/save_backup?stamp=" + new Date().getTime();
-        url = ApiClient.getUrl(url);
-        ApiClient.getUserActivity(url).then(function (responce_message) {
+        url = window.ApiClient.getUrl(url);
+        window.ApiClient.getUserActivity(url).then(function (responce_message) {
             //alert("Loaded Data: " + JSON.stringify(usage_data));
             alert(responce_message[0]);
 
-            ApiClient.getNamedConfiguration('playback_reporting').then(function (config) {
+            window.ApiClient.getNamedConfiguration('playback_reporting').then(function (config) {
                 var backup_path_label = view.querySelector('#backup_path_label');
                 backup_path_label.innerHTML = config.BackupPath;
             });
@@ -102,8 +103,8 @@ const getConfigurationPageUrl = (name) => {
     function loadBackupFile(selectedFile, view) {
         var encoded_path = encodeURI(selectedFile); 
         var url = "user_usage_stats/load_backup?backupfile=" + encoded_path + "&stamp=" + new Date().getTime();
-        url = ApiClient.getUrl(url);
-        ApiClient.getUserActivity(url).then(function (responce_message) {
+        url = window.ApiClient.getUrl(url);
+        window.ApiClient.getUserActivity(url).then(function (responce_message) {
             //alert("Loaded Data Message : " + JSON.stringify(responce_message));
             alert(responce_message[0]);
         });
@@ -112,8 +113,8 @@ const getConfigurationPageUrl = (name) => {
     function showUserList(view) {
 
         var url = "user_usage_stats/user_list?stamp=" + new Date().getTime();
-        url = ApiClient.getUrl(url);
-        ApiClient.getUserActivity(url).then(function (user_list) {
+        url = window.ApiClient.getUrl(url);
+        window.ApiClient.getUserActivity(url).then(function (user_list) {
             //alert("Loaded Data: " + JSON.stringify(user_list));
 
             var add_user_list = view.querySelector('#user_list_for_add');
@@ -165,19 +166,19 @@ const getConfigurationPageUrl = (name) => {
 
             function files_to_keep_changed() {
                 var max_files = backup_files_to_keep.value;
-                ApiClient.getNamedConfiguration('playback_reporting').then(function (config) {
+                window.ApiClient.getNamedConfiguration('playback_reporting').then(function (config) {
                     config.MaxBackupFiles = max_files;
                     console.log("New Config Settings : " + JSON.stringify(config));
-                    ApiClient.updateNamedConfiguration('playback_reporting', config);
+                    window.ApiClient.updateNamedConfiguration('playback_reporting', config);
                 });
             }
 
             function setting_changed() {
                 var max_age = max_data_age_select.value;
-                ApiClient.getNamedConfiguration('playback_reporting').then(function (config) {
+                window.ApiClient.getNamedConfiguration('playback_reporting').then(function (config) {
                     config.MaxDataAge = max_age;
                     console.log("New Config Settings : " + JSON.stringify(config));
-                    ApiClient.updateNamedConfiguration('playback_reporting', config);
+                    window.ApiClient.updateNamedConfiguration('playback_reporting', config);
                 });
             }
 
@@ -213,14 +214,14 @@ const getConfigurationPageUrl = (name) => {
             var remove_unknown_button = view.querySelector('#remove_unknown_button');
             remove_unknown_button.addEventListener("click", function () {
                 var url = "user_usage_stats/user_manage/remove_unknown/none" + "?stamp=" + new Date().getTime();
-                url = ApiClient.getUrl(url);
-                ApiClient.getUserActivity(url).then(function (result) {
+                url = window.ApiClient.getUrl(url);
+                window.ApiClient.getUserActivity(url).then(function (result) {
                     alert("Unknown user activity removed.");
                 });
 
             });            
 
-            ApiClient.getNamedConfiguration('playback_reporting').then(function (config) {
+            window.ApiClient.getNamedConfiguration('playback_reporting').then(function (config) {
                 loadPage(view, config);
             });
 
@@ -231,8 +232,8 @@ const getConfigurationPageUrl = (name) => {
                 var add_user_list = view.querySelector('#user_list_for_add');
                 var selected_user_id = add_user_list.options[add_user_list.selectedIndex].value;
                 var url = "user_usage_stats/user_manage/add/" + selected_user_id + "?stamp=" + new Date().getTime();
-                url = ApiClient.getUrl(url);
-                ApiClient.getUserActivity(url).then(function (result) {
+                url = window.ApiClient.getUrl(url);
+                window.ApiClient.getUserActivity(url).then(function (result) {
                     //alert(result);
                     showUserList(view);
                 });
@@ -244,8 +245,8 @@ const getConfigurationPageUrl = (name) => {
                 var add_user_list = view.querySelector('#user_list_for_add');
                 var selected_user_id = add_user_list.options[add_user_list.selectedIndex].value;
                 var url = "user_usage_stats/user_manage/remove/" + selected_user_id + "?stamp=" + new Date().getTime();
-                url = ApiClient.getUrl(url);
-                ApiClient.getUserActivity(url).then(function (result) {
+                url = window.ApiClient.getUrl(url);
+                window.ApiClient.getUserActivity(url).then(function (result) {
                     //alert(result);
                     showUserList(view);
                 });

--- a/Jellyfin.Plugin.PlaybackReporting/Pages/user_playback_report.js
+++ b/Jellyfin.Plugin.PlaybackReporting/Pages/user_playback_report.js
@@ -454,8 +454,11 @@ const getConfigurationPageUrl = (name) => {
 
             LibraryMenu.setTabs('playback_reporting', 1, getTabs);
 
-            import('./Chart.bundle.min.js').then(({default: d3}) => {
-
+            import(
+                window.ApiClient.getUrl("web/ConfigurationPage", {
+                  name: "Chart.bundle.min.js",
+                })
+            ).then(({default: d3}) => {
                 // get filter types form sever
                 var filter_url = window.ApiClient.getUrl("user_usage_stats/type_filter_list");
                 window.ApiClient.getUserActivity(filter_url).then(function (filter_data) {

--- a/Jellyfin.Plugin.PlaybackReporting/Pages/user_playback_report.js
+++ b/Jellyfin.Plugin.PlaybackReporting/Pages/user_playback_report.js
@@ -14,8 +14,9 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see<http://www.gnu.org/licenses/>.
 */
 
-define(['libraryMenu'], function (libraryMenu) {
-    'use strict';
+const getConfigurationPageUrl = (name) => {
+    return 'configurationpage?name=' + encodeURIComponent(name);
+}
 
     var my_bar_chart = null;
     var filter_names = [];
@@ -415,37 +416,37 @@ define(['libraryMenu'], function (libraryMenu) {
     function getTabs() {
         var tabs = [
             {
-                href: Dashboard.getConfigurationPageUrl('user_report'),
+                href: getConfigurationPageUrl('user_report'),
                 name: 'Users'
             },
             {
-                href: Dashboard.getConfigurationPageUrl('user_playback_report'),
+                href: getConfigurationPageUrl('user_playback_report'),
                 name: 'Playback'
             },
             {
-                href: Dashboard.getConfigurationPageUrl('breakdown_report'),
+                href: getConfigurationPageUrl('breakdown_report'),
                 name: 'Breakdown'
             },
             {
-                href: Dashboard.getConfigurationPageUrl('hourly_usage_report'),
+                href: getConfigurationPageUrl('hourly_usage_report'),
                 name: 'Usage'
             },
             {
-                href: Dashboard.getConfigurationPageUrl('duration_histogram_report'),
+                href: getConfigurationPageUrl('duration_histogram_report'),
                 name: 'Duration'
             },
             {
-                href: Dashboard.getConfigurationPageUrl('custom_query'),
+                href: getConfigurationPageUrl('custom_query'),
                 name: 'Query'
             },
             {
-                href: Dashboard.getConfigurationPageUrl('playback_report_settings'),
+                href: getConfigurationPageUrl('playback_report_settings'),
                 name: 'Settings'
             }];
         return tabs;
     }
 
-    return function (view, params) {
+    export default function (view, params) {
 
         // init code here
         // https://cdnjs.cloudflare.com/ajax/libs/Chart.js/2.7.2/Chart.bundle.min.js
@@ -533,4 +534,4 @@ define(['libraryMenu'], function (libraryMenu) {
 
         });
     };
-});
+

--- a/Jellyfin.Plugin.PlaybackReporting/Pages/user_playback_report.js
+++ b/Jellyfin.Plugin.PlaybackReporting/Pages/user_playback_report.js
@@ -27,7 +27,7 @@ const getConfigurationPageUrl = (name) => {
         return local.toJSON().slice(0, 10);
     });
 
-    ApiClient.getUserActivity = function (url_to_get) {
+    window.ApiClient.getUserActivity = function (url_to_get) {
         console.log("getUserActivity Url = " + url_to_get);
         return this.ajax({
             type: "GET",
@@ -36,7 +36,7 @@ const getConfigurationPageUrl = (name) => {
         });
     };
 
-    ApiClient.sendCustomQuery = function (url_to_get, query_data) {
+    window.ApiClient.sendCustomQuery = function (url_to_get, query_data) {
         var post_data = JSON.stringify(query_data);
         console.log("sendCustomQuery url  = " + url_to_get);
         console.log("sendCustomQuery data = " + post_data);
@@ -267,10 +267,10 @@ const getConfigurationPageUrl = (name) => {
         }
 
         var url_to_get = "user_usage_stats/" + user_id + "/" + data_label + "/GetItems?filter=" + filter.join(",") + "&stamp=" + new Date().getTime();
-        url_to_get = ApiClient.getUrl(url_to_get);
+        url_to_get = window.ApiClient.getUrl(url_to_get);
         console.log("User Report Details Url: " + url_to_get);
 
-        ApiClient.getUserActivity(url_to_get).then(function (usage_data) {
+        window.ApiClient.getUserActivity(url_to_get).then(function (usage_data) {
             //alert("Loaded Data: " + JSON.stringify(usage_data));
             populate_report(user_name, user_id, data_label, usage_data, view);
         });
@@ -286,14 +286,14 @@ const getConfigurationPageUrl = (name) => {
         console.log("Remove Item Query : " + sql);
 
         var url = "user_usage_stats/submit_custom_query?stamp=" + new Date().getTime();
-        url = ApiClient.getUrl(url);
+        url = window.ApiClient.getUrl(url);
 
         var query_data = {
             CustomQueryString: sql,
             ReplaceUserId: false
         };
 
-        ApiClient.sendCustomQuery(url, query_data).then(function (result) {
+        window.ApiClient.sendCustomQuery(url, query_data).then(function (result) {
             var message = result["message"];
             console.log("Remove Item Result : " + message);
             display_user_report(user_name, user_id, data_label, view);
@@ -454,11 +454,11 @@ const getConfigurationPageUrl = (name) => {
 
             LibraryMenu.setTabs('playback_reporting', 1, getTabs);
 
-            require([Dashboard.getConfigurationResourceUrl('Chart.bundle.min.js')], function (d3) {
+            import('./Chart.bundle.min.js').then(({default: d3}) => {
 
                 // get filter types form sever
-                var filter_url = ApiClient.getUrl("user_usage_stats/type_filter_list");
-                ApiClient.getUserActivity(filter_url).then(function (filter_data) {
+                var filter_url = window.ApiClient.getUrl("user_usage_stats/type_filter_list");
+                window.ApiClient.getUserActivity(filter_url).then(function (filter_data) {
                     filter_names = filter_data;
                 
                     // build filter list
@@ -488,8 +488,8 @@ const getConfigurationPageUrl = (name) => {
                     var days = parseInt(weeks.value) * 7;
 
                     var url = "user_usage_stats/PlayActivity?filter=" + filter_names.join(",") + "&days=" + days + "&end_date=" + end_date.value + "&data_type=count&stamp=" + new Date().getTime();
-                    url = ApiClient.getUrl(url);
-                    ApiClient.getUserActivity(url).then(function (usage_data) {
+                    url = window.ApiClient.getUrl(url);
+                    window.ApiClient.getUserActivity(url).then(function (usage_data) {
                         //alert("Loaded Data: " + JSON.stringify(usage_data));
                         draw_graph(view, d3, usage_data);
                     });
@@ -514,8 +514,8 @@ const getConfigurationPageUrl = (name) => {
                         
 
                         var filtered_url = "user_usage_stats/PlayActivity?filter=" + filter.join(",") + "&days=" + days + "&end_date=" + end_date.value + "&data_type=" + data_t + "&stamp=" + new Date().getTime();
-                        filtered_url = ApiClient.getUrl(filtered_url);
-                        ApiClient.getUserActivity(filtered_url).then(function (usage_data) {
+                        filtered_url = window.ApiClient.getUrl(filtered_url);
+                        window.ApiClient.getUserActivity(filtered_url).then(function (usage_data) {
                             draw_graph(view, d3, usage_data);
                         });
                     }

--- a/Jellyfin.Plugin.PlaybackReporting/Pages/user_report.js
+++ b/Jellyfin.Plugin.PlaybackReporting/Pages/user_report.js
@@ -14,8 +14,9 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see<http://www.gnu.org/licenses/>.
 */
 
-define(['libraryMenu'], function (libraryMenu) {
-    'use strict';
+const getConfigurationPageUrl = (name) => {
+    return 'configurationpage?name=' + encodeURIComponent(name);
+}
 
     Date.prototype.toDateInputValue = (function () {
         var local = new Date(this);
@@ -35,37 +36,37 @@ define(['libraryMenu'], function (libraryMenu) {
     function getTabs() {
         var tabs = [
             {
-                href: Dashboard.getConfigurationPageUrl('user_report'),
+                href: getConfigurationPageUrl('user_report'),
                 name: 'Users'
             },
             {
-                href: Dashboard.getConfigurationPageUrl('user_playback_report'),
+                href: getConfigurationPageUrl('user_playback_report'),
                 name: 'Playback'
             },
             {
-                href: Dashboard.getConfigurationPageUrl('breakdown_report'),
+                href: getConfigurationPageUrl('breakdown_report'),
                 name: 'Breakdown'
             },
             {
-                href: Dashboard.getConfigurationPageUrl('hourly_usage_report'),
+                href: getConfigurationPageUrl('hourly_usage_report'),
                 name: 'Usage'
             },
             {
-                href: Dashboard.getConfigurationPageUrl('duration_histogram_report'),
+                href: getConfigurationPageUrl('duration_histogram_report'),
                 name: 'Duration'
             },
             {
-                href: Dashboard.getConfigurationPageUrl('custom_query'),
+                href: getConfigurationPageUrl('custom_query'),
                 name: 'Query'
             },
             {
-                href: Dashboard.getConfigurationPageUrl('playback_report_settings'),
+                href: getConfigurationPageUrl('playback_report_settings'),
                 name: 'Settings'
             }];
         return tabs;
     }
 
-    return function (view, params) {
+    export default function (view, params) {
 
         // init code here
         view.addEventListener('viewshow', function (e) {
@@ -129,4 +130,4 @@ define(['libraryMenu'], function (libraryMenu) {
 
         });
     };
-});
+

--- a/Jellyfin.Plugin.PlaybackReporting/Pages/user_report.js
+++ b/Jellyfin.Plugin.PlaybackReporting/Pages/user_report.js
@@ -24,7 +24,7 @@ const getConfigurationPageUrl = (name) => {
         return local.toJSON().slice(0, 10);
     });
 
-    ApiClient.getUserActivity = function (url_to_get) {
+    window.ApiClient.getUserActivity = function (url_to_get) {
         console.log("getUserActivity Url = " + url_to_get);
         return this.ajax({
             type: "GET",
@@ -88,8 +88,8 @@ const getConfigurationPageUrl = (name) => {
                 if (days == -7) days = 18250;
 
                 var url = "user_usage_stats/user_activity?days=" + days + "&end_date=" + end_date.value + "&stamp=" + new Date().getTime();
-                url = ApiClient.getUrl(url);
-                ApiClient.getUserActivity(url).then(function (user_data) {
+                url = window.ApiClient.getUrl(url);
+                window.ApiClient.getUserActivity(url).then(function (user_data) {
                     console.log("usage_data: " + JSON.stringify(user_data));
                     var table_body = view.querySelector('#user_report_results');
                     var row_html = "";
@@ -102,7 +102,7 @@ const getConfigurationPageUrl = (name) => {
                         var user_image = "assets/img/avatar.png";
                         if (user_info.has_image) {
                             user_image = "Users/" + user_info.user_id + "/Images/Primary?width=50";
-                            user_image = ApiClient.getUrl(user_image);
+                            user_image = window.ApiClient.getUrl(user_image);
                         }                      
 
                         row_html += "<td><img src='" + user_image + "' width='50px' style='background-color: black;'></td>";


### PR DESCRIPTION
Summary of changes
----------------------------
`Dashboard.getConfigurationPageUrl()` is removed from Jellyfin.

```javascript
const getConfigurationPageUrl = (name) => {
    return 'configurationpage?name=' + encodeURIComponent(name);
}
```
---

`ApiClient` -> `window.ApiClient`

---

`define()` is removed, `export default` instead of the return (ES6)

---

```javascript
require([Dashboard.getConfigurationResourceUrl('Chart.bundle.min.js')], function (d3) {
```
->
```javascript
import(
    window.ApiClient.getUrl("web/ConfigurationPage", {
        name: "Chart.bundle.min.js",
    })
).then(({default: d3}) => {
```
(ES6)