### PR TITLE
Fix query to PlayActivity endpoint on User Playback Report

### DIFF
--- a/Jellyfin.Plugin.PlaybackReporting/Api/PlaybackReportingActivityController.cs
+++ b/Jellyfin.Plugin.PlaybackReporting/Api/PlaybackReportingActivityController.cs
@@ -205,7 +205,7 @@ namespace Jellyfin.Plugin.PlaybackReporting.Api
         /// <returns></returns>
         [HttpGet("{userId}/{date}/GetItems")]
         [ProducesResponseType(StatusCodes.Status200OK)]
-        public ActionResult GetUserReportData([FromRoute] string userId, [FromRoute] string date, [FromRoute] string? filter)
+        public ActionResult GetUserReportData([FromRoute] string userId, [FromRoute] string date, [FromQuery] string? filter)
         {
             string[] filter_tokens = Array.Empty<string>();
             if (filter != null)

--- a/Jellyfin.Plugin.PlaybackReporting/Pages/user_playback_report.js
+++ b/Jellyfin.Plugin.PlaybackReporting/Pages/user_playback_report.js
@@ -490,7 +490,7 @@ const getConfigurationPageUrl = (name) => {
                     weeks.addEventListener("change", process_click);
                     var days = parseInt(weeks.value) * 7;
 
-                    var url = "user_usage_stats/PlayActivity?filter=" + filter_names.join(",") + "&days=" + days + "&end_date=" + end_date.value + "&data_type=count&stamp=" + new Date().getTime();
+                    var url = "user_usage_stats/PlayActivity?filter=" + filter_names.join(",") + "&days=" + days + "&endDate=" + end_date.value + "&dataType=count&stamp=" + new Date().getTime();
                     url = window.ApiClient.getUrl(url);
                     window.ApiClient.getUserActivity(url).then(function (usage_data) {
                         //alert("Loaded Data: " + JSON.stringify(usage_data));
@@ -516,7 +516,7 @@ const getConfigurationPageUrl = (name) => {
                         days = parseInt(weeks.value) * 7;
 
 
-                        var filtered_url = "user_usage_stats/PlayActivity?filter=" + filter.join(",") + "&days=" + days + "&end_date=" + end_date.value + "&data_type=" + data_t + "&stamp=" + new Date().getTime();
+                        var filtered_url = "user_usage_stats/PlayActivity?filter=" + filter.join(",") + "&days=" + days + "&endDate=" + end_date.value + "&dataType=" + data_t + "&stamp=" + new Date().getTime();
                         filtered_url = window.ApiClient.getUrl(filtered_url);
                         window.ApiClient.getUserActivity(filtered_url).then(function (usage_data) {
                             draw_graph(view, d3, usage_data);


### PR DESCRIPTION
It seems that the query params in the Controller were updated but the
javascript file calling the API was not updated to match. This should
fix issue #32.

This also fixes a bug when you select a bar of the Playback report page and the table shows no results.