### PR TITLE
Feature/client timezone awareness

### DIFF
--- a/Jellyfin.Plugin.PlaybackReporting/Api/PlaybackReportingActivityController.cs
+++ b/Jellyfin.Plugin.PlaybackReporting/Api/PlaybackReportingActivityController.cs
@@ -83,9 +83,9 @@ namespace Jellyfin.Plugin.PlaybackReporting.Api
         /// <returns></returns>
         [HttpGet("user_activity")]
         [ProducesResponseType(StatusCodes.Status200OK)]
-        public ActionResult GetUserReport([FromQuery] int days, [FromQuery] DateTime? endDate)
+        public ActionResult GetUserReport([FromQuery] int days, [FromQuery] DateTime? endDate, int? timezoneOffset)
         {
-            List<Dictionary<string, object>> report = _repository.GetUserReport(days, endDate ?? DateTime.Now);
+            List<Dictionary<string, object>> report = _repository.GetUserReport(days, endDate ?? DateTime.Now, timezoneOffset ?? 0);
 
             foreach(var user_info in report)
             {
@@ -376,7 +376,7 @@ namespace Jellyfin.Plugin.PlaybackReporting.Api
         /// <returns></returns>
         [HttpGet("HourlyReport")]
         [ProducesResponseType(StatusCodes.Status200OK)]
-        public ActionResult GetHourlyReport(int days, DateTime? endDate, string? filter)
+        public ActionResult GetHourlyReport(int days, DateTime? endDate, string? filter, [FromQuery] int? timezoneOffset)
         {
             string[] filter_tokens = Array.Empty<string>();
             if (filter != null)
@@ -386,7 +386,7 @@ namespace Jellyfin.Plugin.PlaybackReporting.Api
 
             endDate ??= DateTime.Now;
 
-            SortedDictionary<string, int> report = _repository.GetHourlyUsageReport(days, endDate.Value, filter_tokens);
+            SortedDictionary<string, int> report = _repository.GetHourlyUsageReport(days, endDate.Value, filter_tokens, timezoneOffset ?? 0);
 
             for (int day = 0; day < 7; day++)
             {
@@ -413,9 +413,9 @@ namespace Jellyfin.Plugin.PlaybackReporting.Api
         /// <returns></returns>
         [HttpGet("{breakdownType}/BreakdownReport")]
         [ProducesResponseType(StatusCodes.Status200OK)]
-        public ActionResult GetBreakdownReport([FromRoute] string breakdownType, int days, DateTime? endDate)
+        public ActionResult GetBreakdownReport([FromRoute] string breakdownType, int days, DateTime? endDate, [FromQuery] int? timezoneOffset)
         {
-            List<Dictionary<string, object>> report = _repository.GetBreakdownReport(days, endDate ?? DateTime.Now, breakdownType);
+            List<Dictionary<string, object>> report = _repository.GetBreakdownReport(days, endDate ?? DateTime.Now, breakdownType, timezoneOffset ?? 0);
 
             if (breakdownType == "UserId")
             {
@@ -490,9 +490,9 @@ namespace Jellyfin.Plugin.PlaybackReporting.Api
         /// <returns></returns>
         [HttpGet("GetTvShowsReport")]
         [ProducesResponseType(StatusCodes.Status200OK)]
-        public ActionResult GetTvShowsReport(int days, DateTime? endDate)
+        public ActionResult GetTvShowsReport(int days, DateTime? endDate, [FromQuery] int? timezoneOffset)
         {
-            return Ok(_repository.GetTvShowReport(days, endDate ?? DateTime.Now));
+            return Ok(_repository.GetTvShowReport(days, endDate ?? DateTime.Now, timezoneOffset ?? 0));
         }
 
         /// <summary>
@@ -504,9 +504,9 @@ namespace Jellyfin.Plugin.PlaybackReporting.Api
         /// <returns></returns>
         [HttpGet("MoviesReport")]
         [ProducesResponseType(StatusCodes.Status200OK)]
-        public ActionResult GetMovieReport(int days, DateTime? endDate)
+        public ActionResult GetMovieReport(int days, DateTime? endDate, [FromQuery] int? timezoneOffset)
         {
-            return Ok(_repository.GetMoviesReport(days, endDate ?? DateTime.Now));
+            return Ok(_repository.GetMoviesReport(days, endDate ?? DateTime.Now, timezoneOffset ?? 0));
         }
 
         public class CustomQueryData

--- a/Jellyfin.Plugin.PlaybackReporting/Api/PlaybackReportingActivityController.cs
+++ b/Jellyfin.Plugin.PlaybackReporting/Api/PlaybackReportingActivityController.cs
@@ -205,7 +205,7 @@ namespace Jellyfin.Plugin.PlaybackReporting.Api
         /// <returns></returns>
         [HttpGet("{userId}/{date}/GetItems")]
         [ProducesResponseType(StatusCodes.Status200OK)]
-        public ActionResult GetUserReportData([FromRoute] string userId, [FromRoute] string date, [FromQuery] string? filter)
+        public ActionResult GetUserReportData([FromRoute] string userId, [FromRoute] string date, [FromQuery] string? filter, [FromQuery] int? timezoneOffset)
         {
             string[] filter_tokens = Array.Empty<string>();
             if (filter != null)
@@ -213,7 +213,7 @@ namespace Jellyfin.Plugin.PlaybackReporting.Api
                 filter_tokens = filter.Split(',');
             }
 
-            List<Dictionary<string, string>> results = _repository.GetUsageForUser(date, userId, filter_tokens);
+            List<Dictionary<string, string>> results = _repository.GetUsageForUser(date, userId, filter_tokens, timezoneOffset ?? 0);
 
             List<Dictionary<string, object>> user_activity = new List<Dictionary<string, object>>();
 
@@ -299,7 +299,7 @@ namespace Jellyfin.Plugin.PlaybackReporting.Api
         /// <returns></returns>
         [HttpGet("PlayActivity")]
         [ProducesResponseType(StatusCodes.Status200OK)]
-        public ActionResult GetUsageStats(int days, DateTime? endDate, string? filter, string? dataType)
+        public ActionResult GetUsageStats(int days, DateTime? endDate, string? filter, string? dataType, int? timezoneOffset)
         {
             string[] filter_tokens = Array.Empty<string>();
             if (filter != null)
@@ -309,7 +309,7 @@ namespace Jellyfin.Plugin.PlaybackReporting.Api
 
             endDate ??= DateTime.Now;
 
-            Dictionary<String, Dictionary<string, int>> results = _repository.GetUsageForDays(days, endDate.Value, filter_tokens, dataType);
+            Dictionary<String, Dictionary<string, int>> results = _repository.GetUsageForDays(days, endDate.Value, filter_tokens, dataType, timezoneOffset ?? 0);
 
             // add empty user for labels
             results.Add("labels_user", new Dictionary<string, int>());

--- a/Jellyfin.Plugin.PlaybackReporting/Api/PlaybackReportingActivityController.cs
+++ b/Jellyfin.Plugin.PlaybackReporting/Api/PlaybackReportingActivityController.cs
@@ -83,7 +83,7 @@ namespace Jellyfin.Plugin.PlaybackReporting.Api
         /// <returns></returns>
         [HttpGet("user_activity")]
         [ProducesResponseType(StatusCodes.Status200OK)]
-        public ActionResult GetUserReport([FromQuery] int days, [FromQuery] DateTime? endDate, int? timezoneOffset)
+        public ActionResult GetUserReport([FromQuery] int days, [FromQuery] DateTime? endDate, [FromQuery] int? timezoneOffset)
         {
             List<Dictionary<string, object>> report = _repository.GetUserReport(days, endDate ?? DateTime.Now, timezoneOffset ?? 0);
 
@@ -299,7 +299,7 @@ namespace Jellyfin.Plugin.PlaybackReporting.Api
         /// <returns></returns>
         [HttpGet("PlayActivity")]
         [ProducesResponseType(StatusCodes.Status200OK)]
-        public ActionResult GetUsageStats(int days, DateTime? endDate, string? filter, string? dataType, int? timezoneOffset)
+        public ActionResult GetUsageStats(int days, DateTime? endDate, string? filter, string? dataType, [FromQuery] int? timezoneOffset)
         {
             string[] filter_tokens = Array.Empty<string>();
             if (filter != null)

--- a/Jellyfin.Plugin.PlaybackReporting/Data/ActivityRepository.cs
+++ b/Jellyfin.Plugin.PlaybackReporting/Data/ActivityRepository.cs
@@ -505,7 +505,7 @@ namespace Jellyfin.Plugin.PlaybackReporting.Data
             return usage;
         }
 
-        public SortedDictionary<string, int> GetHourlyUsageReport(int days, DateTime endDate, string[] types)
+        public SortedDictionary<string, int> GetHourlyUsageReport(int days, DateTime endDate, string[] types, int timezoneOffset)
         {
             List<string> filters = new List<string>();
             foreach (string filter in types)
@@ -515,6 +515,7 @@ namespace Jellyfin.Plugin.PlaybackReporting.Data
 
             SortedDictionary<string, int> report_data = new SortedDictionary<string, int>();
 
+            endDate = endDate.AddHours(timezoneOffset);
             DateTime start_date = endDate.Subtract(new TimeSpan(days, 0, 0, 0));
 
             string sql = "SELECT DateCreated, PlayDuration ";
@@ -527,12 +528,12 @@ namespace Jellyfin.Plugin.PlaybackReporting.Data
             {
                 using var connection = CreateConnection(true);
                 using var statement = connection.PrepareStatement(sql);
-                statement.TryBind("@start_date", start_date.ToString("yyyy-MM-dd 00:00:00"));
-                statement.TryBind("@end_date", endDate.ToString("yyyy-MM-dd 23:59:59"));
+                statement.TryBind("@start_date", start_date.ToString(DATE_TIME_FORMAT));
+                statement.TryBind("@end_date", endDate.ToString(DATE_TIME_FORMAT));
 
                 foreach (var row in statement.ExecuteQuery())
                 {
-                    DateTime date = row[0].ReadDateTime().ToLocalTime();
+                    DateTime date = row[0].ReadDateTime().AddHours(-timezoneOffset);
                     int duration = row[1].ToInt();
 
                     int seconds_left_in_hour = 3600 - (date.Minute * 60 + date.Second);
@@ -572,12 +573,13 @@ namespace Jellyfin.Plugin.PlaybackReporting.Data
             }
         }
 
-        public List<Dictionary<string, object>> GetBreakdownReport(int days, DateTime endDate, string type)
+        public List<Dictionary<string, object>> GetBreakdownReport(int days, DateTime endDate, string type, int timezoneOffset)
         {
             // UserId ItemType PlaybackMethod ClientName DeviceName
 
             List<Dictionary<string, object>> report = new List<Dictionary<string, object>>();
 
+            endDate = endDate.AddHours(timezoneOffset);
             DateTime start_date = endDate.Subtract(new TimeSpan(days, 0, 0, 0));
 
             string sql = "SELECT " + type + ", COUNT(1) AS PlayCount, SUM(PlayDuration) AS Seconds ";
@@ -590,8 +592,8 @@ namespace Jellyfin.Plugin.PlaybackReporting.Data
             {
                 using var connection = CreateConnection(true);
                 using var statement = connection.PrepareStatement(sql);
-                statement.TryBind("@start_date", start_date.ToString("yyyy-MM-dd 00:00:00"));
-                statement.TryBind("@end_date", endDate.ToString("yyyy-MM-dd 23:59:59"));
+                statement.TryBind("@start_date", start_date.ToString(DATE_TIME_FORMAT));
+                statement.TryBind("@end_date", endDate.ToString(DATE_TIME_FORMAT));
 
                 foreach (var row in statement.ExecuteQuery())
                 {
@@ -656,10 +658,11 @@ namespace Jellyfin.Plugin.PlaybackReporting.Data
             return report;
         }
 
-        public List<Dictionary<string, object>> GetTvShowReport(int days, DateTime endDate)
+        public List<Dictionary<string, object>> GetTvShowReport(int days, DateTime endDate, int timezoneOffset)
         {
             List<Dictionary<string, object>> report = new List<Dictionary<string, object>>();
 
+            endDate = endDate.AddHours(timezoneOffset);
             DateTime start_date = endDate.Subtract(new TimeSpan(days, 0, 0, 0));
 
             string sql = "";
@@ -676,8 +679,8 @@ namespace Jellyfin.Plugin.PlaybackReporting.Data
             {
                 using var connection = CreateConnection(true);
                 using var statement = connection.PrepareStatement(sql);
-                statement.TryBind("@start_date", start_date.ToString("yyyy-MM-dd 00:00:00"));
-                statement.TryBind("@end_date", endDate.ToString("yyyy-MM-dd 23:59:59"));
+                statement.TryBind("@start_date", start_date.ToString(DATE_TIME_FORMAT));
+                statement.TryBind("@end_date", endDate.ToString(DATE_TIME_FORMAT));
 
                 foreach (var row in statement.ExecuteQuery())
                 {
@@ -698,10 +701,11 @@ namespace Jellyfin.Plugin.PlaybackReporting.Data
             return report;
         }
 
-        public List<Dictionary<string, object>> GetMoviesReport(int days, DateTime endDate)
+        public List<Dictionary<string, object>> GetMoviesReport(int days, DateTime endDate, int timezoneOffset)
         {
             List<Dictionary<string, object>> report = new List<Dictionary<string, object>>();
 
+            endDate = endDate.AddHours(timezoneOffset);
             DateTime start_date = endDate.Subtract(new TimeSpan(days, 0, 0, 0));
 
             string sql = "";
@@ -718,8 +722,8 @@ namespace Jellyfin.Plugin.PlaybackReporting.Data
             {
                 using var connection = CreateConnection(true);
                 using var statement = connection.PrepareStatement(sql);
-                statement.TryBind("@start_date", start_date.ToString("yyyy-MM-dd 00:00:00"));
-                statement.TryBind("@end_date", endDate.ToString("yyyy-MM-dd 23:59:59"));
+                statement.TryBind("@start_date", start_date.ToString(DATE_TIME_FORMAT));
+                statement.TryBind("@end_date", endDate.ToString(DATE_TIME_FORMAT));
 
                 foreach (var row in statement.ExecuteQuery())
                 {
@@ -738,10 +742,11 @@ namespace Jellyfin.Plugin.PlaybackReporting.Data
             return report;
         }
 
-        public List<Dictionary<string, object>> GetUserReport(int days, DateTime endDate)
+        public List<Dictionary<string, object>> GetUserReport(int days, DateTime endDate, int timezoneOffset)
         {
             List<Dictionary<string, object>> report = new List<Dictionary<string, object>>();
 
+            endDate = endDate.AddHours(timezoneOffset);
             DateTime start_date = endDate.Subtract(new TimeSpan(days, 0, 0, 0));
 
             string sql = "";

--- a/Jellyfin.Plugin.PlaybackReporting/Data/ActivityRepository.cs
+++ b/Jellyfin.Plugin.PlaybackReporting/Data/ActivityRepository.cs
@@ -26,6 +26,7 @@ namespace Jellyfin.Plugin.PlaybackReporting.Data
 {
     public class ActivityRepository : BaseSqliteRepository, IActivityRepository
     {
+        private static string DATE_TIME_FORMAT = "yyyy-MM-dd HH:mm:ss";
         private readonly ILogger<ActivityRepository> _logger;
         protected IFileSystem FileSystem { get; private set; }
 
@@ -392,7 +393,7 @@ namespace Jellyfin.Plugin.PlaybackReporting.Data
             }
         }
 
-        public List<Dictionary<string, string>> GetUsageForUser(string date, string userId, string[] types)
+        public List<Dictionary<string, string>> GetUsageForUser(string date, string userId, string[] types, int timezoneOffset)
         {
             List<string> filters = new List<string>();
             foreach (string filter in types)
@@ -412,14 +413,17 @@ namespace Jellyfin.Plugin.PlaybackReporting.Data
             {
                 using var connection = CreateConnection(true);
                 using var statement = connection.PrepareStatement(sql_query);
-                statement.TryBind("@date_from", date + " 00:00:00");
-                statement.TryBind("@date_to", date + " 23:59:59");
+                var fromDate = DateTime.Parse(date + " 00:00:00").AddHours(-timezoneOffset);
+                var toDate = fromDate.AddHours(23).AddMinutes(59).AddSeconds(59);
+                statement.TryBind("@date_from", fromDate.ToString(DATE_TIME_FORMAT));
+                statement.TryBind("@date_to", toDate.ToString(DATE_TIME_FORMAT));
                 statement.TryBind("@user_id", userId);
                 foreach (var row in statement.ExecuteQuery())
                 {
+                    var time = row[0].ReadDateTime();
                     Dictionary<string, string> item = new Dictionary<string, string>
                     {
-                        ["Time"] = row[0].ReadDateTime().ToLocalTime().ToString("HH:mm"),
+                        ["Time"] = time.AddHours(timezoneOffset).ToString("h:mm tt"),
                         ["Id"] = row[1].ToString(),
                         ["Type"] = row[2].ToString(),
                         ["ItemName"] = row[3].ToString(),
@@ -437,7 +441,7 @@ namespace Jellyfin.Plugin.PlaybackReporting.Data
             return items;
         }
 
-        public Dictionary<String, Dictionary<string, int>> GetUsageForDays(int days, DateTime endDate, string[] types, string? dataType)
+        public Dictionary<String, Dictionary<string, int>> GetUsageForDays(int days, DateTime endDate, string[] types, string? dataType, int timezoneOffset)
         {
             List<string> filters = new List<string>();
             foreach (string filter in types)
@@ -448,11 +452,11 @@ namespace Jellyfin.Plugin.PlaybackReporting.Data
             string sql_query = "";
             if (dataType == "count")
             {
-                sql_query += "SELECT UserId, strftime('%Y-%m-%d', DateCreated) AS date, COUNT(1) AS count ";
+                sql_query += "SELECT UserId, DateCreated AS date, COUNT(1) AS count ";
             }
             else
             {
-                sql_query += "SELECT UserId, strftime('%Y-%m-%d', DateCreated) AS date, SUM(PlayDuration) AS count ";
+                sql_query += "SELECT UserId, DateCreated AS date, SUM(PlayDuration) AS count ";
             }
             sql_query += "FROM PlaybackActivity ";
             sql_query += "WHERE DateCreated >= @start_date AND DateCreated <= @end_date ";
@@ -460,6 +464,7 @@ namespace Jellyfin.Plugin.PlaybackReporting.Data
             sql_query += "AND UserId not IN (select UserId from UserList) ";
             sql_query += "GROUP BY UserId, date ORDER BY UserId, date ASC";
 
+            endDate = endDate.AddHours(-timezoneOffset);
             DateTime start_date = endDate.Subtract(new TimeSpan(days, 0, 0, 0));
             Dictionary<string, Dictionary<string, int>> usage = new Dictionary<string, Dictionary<string, int>>();
 
@@ -467,25 +472,33 @@ namespace Jellyfin.Plugin.PlaybackReporting.Data
             {
                 using var connection = CreateConnection(true);
                 using var statement = connection.PrepareStatement(sql_query);
-                statement.TryBind("@start_date", start_date.ToString("yyyy-MM-dd 00:00:00"));
-                statement.TryBind("@end_date", endDate.ToString("yyyy-MM-dd 23:59:59"));
+                statement.TryBind("@start_date", start_date.ToString(DATE_TIME_FORMAT));
+                statement.TryBind("@end_date", endDate.ToString(DATE_TIME_FORMAT));
 
                 foreach (var row in statement.ExecuteQuery())
                 {
                     string user_id = row[0].ToString();
-                    Dictionary<string, int> uu;
+                    Dictionary<string, int> userWatchesByDate;
                     if (usage.ContainsKey(user_id))
                     {
-                        uu = usage[user_id];
+                        userWatchesByDate = usage[user_id];
                     }
                     else
                     {
-                        uu = new Dictionary<string, int>();
-                        usage.Add(user_id, uu);
+                        userWatchesByDate = new Dictionary<string, int>();
+                        usage.Add(user_id, userWatchesByDate);
                     }
-                    string date_string = row[1].ToString();
+                    string date_string = DateTime.Parse(row[1].ToString()).AddHours(timezoneOffset).ToString("yyyy-MM-dd");
                     int count_int = row[2].ToInt();
-                    uu.Add(date_string, count_int);
+                    if (userWatchesByDate.ContainsKey(date_string))
+                    {
+                        var count = userWatchesByDate[date_string];
+                        userWatchesByDate[date_string] = count_int + count;
+                    }
+                    else
+                    {
+                        userWatchesByDate.Add(date_string, count_int);
+                    }
                 }
             }
 

--- a/Jellyfin.Plugin.PlaybackReporting/Data/ActivityRepository.cs
+++ b/Jellyfin.Plugin.PlaybackReporting/Data/ActivityRepository.cs
@@ -515,7 +515,7 @@ namespace Jellyfin.Plugin.PlaybackReporting.Data
 
             SortedDictionary<string, int> report_data = new SortedDictionary<string, int>();
 
-            endDate = endDate.AddHours(timezoneOffset);
+            endDate = endDate.AddHours(-timezoneOffset);
             DateTime start_date = endDate.Subtract(new TimeSpan(days, 0, 0, 0));
 
             string sql = "SELECT DateCreated, PlayDuration ";
@@ -533,7 +533,7 @@ namespace Jellyfin.Plugin.PlaybackReporting.Data
 
                 foreach (var row in statement.ExecuteQuery())
                 {
-                    DateTime date = row[0].ReadDateTime().AddHours(-timezoneOffset);
+                    DateTime date = row[0].ReadDateTime().AddHours(timezoneOffset);
                     int duration = row[1].ToInt();
 
                     int seconds_left_in_hour = 3600 - (date.Minute * 60 + date.Second);
@@ -579,7 +579,7 @@ namespace Jellyfin.Plugin.PlaybackReporting.Data
 
             List<Dictionary<string, object>> report = new List<Dictionary<string, object>>();
 
-            endDate = endDate.AddHours(timezoneOffset);
+            endDate = endDate.AddHours(-timezoneOffset);
             DateTime start_date = endDate.Subtract(new TimeSpan(days, 0, 0, 0));
 
             string sql = "SELECT " + type + ", COUNT(1) AS PlayCount, SUM(PlayDuration) AS Seconds ";
@@ -662,7 +662,7 @@ namespace Jellyfin.Plugin.PlaybackReporting.Data
         {
             List<Dictionary<string, object>> report = new List<Dictionary<string, object>>();
 
-            endDate = endDate.AddHours(timezoneOffset);
+            endDate = endDate.AddHours(-timezoneOffset);
             DateTime start_date = endDate.Subtract(new TimeSpan(days, 0, 0, 0));
 
             string sql = "";
@@ -705,7 +705,7 @@ namespace Jellyfin.Plugin.PlaybackReporting.Data
         {
             List<Dictionary<string, object>> report = new List<Dictionary<string, object>>();
 
-            endDate = endDate.AddHours(timezoneOffset);
+            endDate = endDate.AddHours(-timezoneOffset);
             DateTime start_date = endDate.Subtract(new TimeSpan(days, 0, 0, 0));
 
             string sql = "";
@@ -746,7 +746,7 @@ namespace Jellyfin.Plugin.PlaybackReporting.Data
         {
             List<Dictionary<string, object>> report = new List<Dictionary<string, object>>();
 
-            endDate = endDate.AddHours(timezoneOffset);
+            endDate = endDate.AddHours(-timezoneOffset);
             DateTime start_date = endDate.Subtract(new TimeSpan(days, 0, 0, 0));
 
             string sql = "";

--- a/Jellyfin.Plugin.PlaybackReporting/Data/ActivityRepository.cs
+++ b/Jellyfin.Plugin.PlaybackReporting/Data/ActivityRepository.cs
@@ -26,7 +26,7 @@ namespace Jellyfin.Plugin.PlaybackReporting.Data
 {
     public class ActivityRepository : BaseSqliteRepository, IActivityRepository
     {
-        private static string DATE_TIME_FORMAT = "yyyy-MM-dd HH:mm:ss";
+        private static readonly string DATE_TIME_FORMAT = "yyyy-MM-dd HH:mm:ss";
         private readonly ILogger<ActivityRepository> _logger;
         protected IFileSystem FileSystem { get; private set; }
 

--- a/Jellyfin.Plugin.PlaybackReporting/Data/IActivityRepository.cs
+++ b/Jellyfin.Plugin.PlaybackReporting/Data/IActivityRepository.cs
@@ -30,8 +30,8 @@ namespace Jellyfin.Plugin.PlaybackReporting.Data
         void DeleteOldData(DateTime? del_before);
         void AddPlaybackAction(PlaybackInfo play_info);
         void UpdatePlaybackAction(PlaybackInfo play_info);
-        List<Dictionary<string, string>> GetUsageForUser(string date, string user_id, string[] filter);
-        Dictionary<String, Dictionary<string, int>> GetUsageForDays(int days, DateTime end_date, string[] types, string? data_type);
+        List<Dictionary<string, string>> GetUsageForUser(string date, string user_id, string[] filter, int timezoneOffset);
+        Dictionary<String, Dictionary<string, int>> GetUsageForDays(int days, DateTime end_date, string[] types, string? data_type, int timezoneOffset);
         SortedDictionary<string, int> GetHourlyUsageReport(int days, DateTime end_date, string[] types);
         List<Dictionary<string, object>> GetBreakdownReport(int days, DateTime end_date, string type);
         SortedDictionary<int, int> GetDurationHistogram(int days, DateTime end_date, string[] types);

--- a/Jellyfin.Plugin.PlaybackReporting/Data/IActivityRepository.cs
+++ b/Jellyfin.Plugin.PlaybackReporting/Data/IActivityRepository.cs
@@ -32,12 +32,12 @@ namespace Jellyfin.Plugin.PlaybackReporting.Data
         void UpdatePlaybackAction(PlaybackInfo play_info);
         List<Dictionary<string, string>> GetUsageForUser(string date, string user_id, string[] filter, int timezoneOffset);
         Dictionary<String, Dictionary<string, int>> GetUsageForDays(int days, DateTime end_date, string[] types, string? data_type, int timezoneOffset);
-        SortedDictionary<string, int> GetHourlyUsageReport(int days, DateTime end_date, string[] types);
-        List<Dictionary<string, object>> GetBreakdownReport(int days, DateTime end_date, string type);
+        SortedDictionary<string, int> GetHourlyUsageReport(int days, DateTime end_date, string[] types, int timezoneOffset);
+        List<Dictionary<string, object>> GetBreakdownReport(int days, DateTime end_date, string type, int timezoneOffset);
         SortedDictionary<int, int> GetDurationHistogram(int days, DateTime end_date, string[] types);
-        List<Dictionary<string, object>> GetTvShowReport(int days, DateTime end_date);
-        List<Dictionary<string, object>> GetMoviesReport(int days, DateTime end_date);
-        List<Dictionary<string, object>> GetUserReport(int days, DateTime end_date);
+        List<Dictionary<string, object>> GetTvShowReport(int days, DateTime end_date, int timezoneOffset);
+        List<Dictionary<string, object>> GetMoviesReport(int days, DateTime end_date, int timezoneOffset);
+        List<Dictionary<string, object>> GetUserReport(int days, DateTime end_date, int timezoneOffset);
         string RunCustomQuery(string query_string, List<string> col_names, List<List<object>> results);
     }
 }

--- a/Jellyfin.Plugin.PlaybackReporting/Pages/breakdown_report.js
+++ b/Jellyfin.Plugin.PlaybackReporting/Pages/breakdown_report.js
@@ -273,7 +273,7 @@ const getConfigurationPageUrl = (name) => {
                     //Set days filter to 50 years if 'all' option is selected.
                     if (days == -7) days = 18250;
 
-                    const timezoneOffset = new Date().getTimezoneOffset() / 60;
+                    const timezoneOffset = -(new Date().getTimezoneOffset() / 60);
 
                     // build user chart
                     var url = "user_usage_stats/UserId/BreakdownReport?days=" + days + "&end_date=" + end_date.value + "&stamp=" + new Date().getTime() + "&timezoneOffset=" + timezoneOffset;

--- a/Jellyfin.Plugin.PlaybackReporting/Pages/breakdown_report.js
+++ b/Jellyfin.Plugin.PlaybackReporting/Pages/breakdown_report.js
@@ -273,9 +273,10 @@ const getConfigurationPageUrl = (name) => {
                     //Set days filter to 50 years if 'all' option is selected.
                     if (days == -7) days = 18250;
 
+                    const timezoneOffset = new Date().getTimezoneOffset() / 60;
 
                     // build user chart
-                    var url = "user_usage_stats/UserId/BreakdownReport?days=" + days + "&end_date=" + end_date.value + "&stamp=" + new Date().getTime();
+                    var url = "user_usage_stats/UserId/BreakdownReport?days=" + days + "&end_date=" + end_date.value + "&stamp=" + new Date().getTime() + "&timezoneOffset=" + timezoneOffset;
                     url = window.ApiClient.getUrl(url);
                     window.ApiClient.getUserActivity(url).then(function (data) {
                         //alert("Loaded Data: " + JSON.stringify(usage_data));
@@ -283,7 +284,7 @@ const getConfigurationPageUrl = (name) => {
                     });
 
                     // build ItemType chart
-                    var url = "user_usage_stats/ItemType/BreakdownReport?days=" + days + "&end_date=" + end_date.value + "&stamp=" + new Date().getTime();
+                    var url = "user_usage_stats/ItemType/BreakdownReport?days=" + days + "&end_date=" + end_date.value + "&stamp=" + new Date().getTime() + "&timezoneOffset=" + timezoneOffset;
                     url = window.ApiClient.getUrl(url);
                     window.ApiClient.getUserActivity(url).then(function (data) {
                         //alert("Loaded Data: " + JSON.stringify(usage_data));
@@ -291,7 +292,7 @@ const getConfigurationPageUrl = (name) => {
                     });
 
                     // build PlaybackMethod chart
-                    var url = "user_usage_stats/PlaybackMethod/BreakdownReport?days=" + days + "&end_date=" + end_date.value + "&stamp=" + new Date().getTime();
+                    var url = "user_usage_stats/PlaybackMethod/BreakdownReport?days=" + days + "&end_date=" + end_date.value + "&stamp=" + new Date().getTime() + "&timezoneOffset=" + timezoneOffset;
                     url = window.ApiClient.getUrl(url);
                     window.ApiClient.getUserActivity(url).then(function (data) {
                         //alert("Loaded Data: " + JSON.stringify(usage_data));
@@ -299,7 +300,7 @@ const getConfigurationPageUrl = (name) => {
                     });
 
                     // build ClientName chart
-                    var url = "user_usage_stats/ClientName/BreakdownReport?days=" + days + "&end_date=" + end_date.value + "&stamp=" + new Date().getTime();
+                    var url = "user_usage_stats/ClientName/BreakdownReport?days=" + days + "&end_date=" + end_date.value + "&stamp=" + new Date().getTime() + "&timezoneOffset=" + timezoneOffset;
                     url = window.ApiClient.getUrl(url);
                     window.ApiClient.getUserActivity(url).then(function (data) {
                         //alert("Loaded Data: " + JSON.stringify(usage_data));
@@ -307,7 +308,7 @@ const getConfigurationPageUrl = (name) => {
                     });
 
                     // build DeviceName chart
-                    var url = "user_usage_stats/DeviceName/BreakdownReport?days=" + days + "&end_date=" + end_date.value + "&stamp=" + new Date().getTime();
+                    var url = "user_usage_stats/DeviceName/BreakdownReport?days=" + days + "&end_date=" + end_date.value + "&stamp=" + new Date().getTime() + "&timezoneOffset=" + timezoneOffset;
                     url = window.ApiClient.getUrl(url);
                     window.ApiClient.getUserActivity(url).then(function (data) {
                         //alert("Loaded Data: " + JSON.stringify(usage_data));
@@ -315,7 +316,7 @@ const getConfigurationPageUrl = (name) => {
                     });
 
                     // build TvShows chart
-                    var url = "user_usage_stats/GetTvShowsReport?days=" + days + "&end_date=" + end_date.value + "&stamp=" + new Date().getTime();
+                    var url = "user_usage_stats/GetTvShowsReport?days=" + days + "&end_date=" + end_date.value + "&stamp=" + new Date().getTime() + "&timezoneOffset=" + timezoneOffset;
                     url = window.ApiClient.getUrl(url);
                     window.ApiClient.getUserActivity(url).then(function (data) {
                         //alert("Loaded Data: " + JSON.stringify(usage_data));
@@ -323,7 +324,7 @@ const getConfigurationPageUrl = (name) => {
                     });
 
                     // build Movies chart
-                    var url = "user_usage_stats/MoviesReport?days=" + days + "&end_date=" + end_date.value + "&stamp=" + new Date().getTime();
+                    var url = "user_usage_stats/MoviesReport?days=" + days + "&end_date=" + end_date.value + "&stamp=" + new Date().getTime() + "&timezoneOffset=" + timezoneOffset;
                     url = window.ApiClient.getUrl(url);
                     window.ApiClient.getUserActivity(url).then(function (data) {
                         //alert("Loaded Data: " + JSON.stringify(usage_data));

--- a/Jellyfin.Plugin.PlaybackReporting/Pages/hourly_usage_report.js
+++ b/Jellyfin.Plugin.PlaybackReporting/Pages/hourly_usage_report.js
@@ -411,7 +411,8 @@ const getConfigurationPageUrl = (name) => {
                         //Set days filter to 50 years if 'all' option is selected.
                         if (days == -7) days = 18250;
 
-                        var url = "user_usage_stats/HourlyReport?days=" + days + "&end_date=" + end_date.value + "&filter=" + filter.join(",") + "&stamp=" + new Date().getTime();
+                        const timezoneOffset = new Date().getTimezoneOffset() / 60;
+                        var url = "user_usage_stats/HourlyReport?days=" + days + "&end_date=" + end_date.value + "&filter=" + filter.join(",") + "&stamp=" + new Date().getTime() + "&timezoneOffset=" + timezoneOffset;
                         url = window.ApiClient.getUrl(url);
                         window.ApiClient.getUserActivity(url).then(function (usage_data) {
                             //alert("Loaded Data: " + JSON.stringify(usage_data));

--- a/Jellyfin.Plugin.PlaybackReporting/Pages/hourly_usage_report.js
+++ b/Jellyfin.Plugin.PlaybackReporting/Pages/hourly_usage_report.js
@@ -411,7 +411,7 @@ const getConfigurationPageUrl = (name) => {
                         //Set days filter to 50 years if 'all' option is selected.
                         if (days == -7) days = 18250;
 
-                        const timezoneOffset = new Date().getTimezoneOffset() / 60;
+                        const timezoneOffset = -(new Date().getTimezoneOffset() / 60);
                         var url = "user_usage_stats/HourlyReport?days=" + days + "&end_date=" + end_date.value + "&filter=" + filter.join(",") + "&stamp=" + new Date().getTime() + "&timezoneOffset=" + timezoneOffset;
                         url = window.ApiClient.getUrl(url);
                         window.ApiClient.getUserActivity(url).then(function (usage_data) {

--- a/Jellyfin.Plugin.PlaybackReporting/Pages/user_playback_report.js
+++ b/Jellyfin.Plugin.PlaybackReporting/Pages/user_playback_report.js
@@ -266,7 +266,8 @@ const getConfigurationPageUrl = (name) => {
             }
         }
 
-        var url_to_get = "user_usage_stats/" + user_id + "/" + data_label + "/GetItems?filter=" + filter.join(",") + "&stamp=" + new Date().getTime();
+        const tzOffset = -(new Date().getTimezoneOffset() / 60);
+        var url_to_get = "user_usage_stats/" + user_id + "/" + data_label + "/GetItems?filter=" + filter.join(",") + "&stamp=" + new Date().getTime() + "&timezoneOffset=" + tzOffset;
         url_to_get = window.ApiClient.getUrl(url_to_get);
         console.log("User Report Details Url: " + url_to_get);
 
@@ -490,7 +491,8 @@ const getConfigurationPageUrl = (name) => {
                     weeks.addEventListener("change", process_click);
                     var days = parseInt(weeks.value) * 7;
 
-                    var url = "user_usage_stats/PlayActivity?filter=" + filter_names.join(",") + "&days=" + days + "&endDate=" + end_date.value + "&dataType=count&stamp=" + new Date().getTime();
+                    const tzOffset = -(new Date().getTimezoneOffset() / 60);
+                    var url = "user_usage_stats/PlayActivity?filter=" + filter_names.join(",") + "&days=" + days + "&endDate=" + end_date.value + "&dataType=count&stamp=" + new Date().getTime() + "&timezoneOffset=" + tzOffset;
                     url = window.ApiClient.getUrl(url);
                     window.ApiClient.getUserActivity(url).then(function (usage_data) {
                         //alert("Loaded Data: " + JSON.stringify(usage_data));
@@ -516,7 +518,8 @@ const getConfigurationPageUrl = (name) => {
                         days = parseInt(weeks.value) * 7;
 
 
-                        var filtered_url = "user_usage_stats/PlayActivity?filter=" + filter.join(",") + "&days=" + days + "&endDate=" + end_date.value + "&dataType=" + data_t + "&stamp=" + new Date().getTime();
+                        const tzOffset = -(new Date().getTimezoneOffset() / 60);
+                        var filtered_url = "user_usage_stats/PlayActivity?filter=" + filter.join(",") + "&days=" + days + "&endDate=" + end_date.value + "&dataType=" + data_t + "&stamp=" + new Date().getTime() + "&timezoneOffset=" + tzOffset;
                         filtered_url = window.ApiClient.getUrl(filtered_url);
                         window.ApiClient.getUserActivity(filtered_url).then(function (usage_data) {
                             draw_graph(view, d3, usage_data);


### PR DESCRIPTION
This PR lets the client pass their timezone into the APIs so that the Server can adjust the queries and data to be more relevant to the user.

This addresses issue: #24.