### PR TITLE
chore: plugin images

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -16,6 +16,7 @@ jobs:
   analyze:
     name: Analyze
     runs-on: ubuntu-latest
+    if: github.repository == 'jellyfin/jellyfin-plugin-playbackreporting'
 
     strategy:
       fail-fast: false

--- a/.github/workflows/create-github-release.yml
+++ b/.github/workflows/create-github-release.yml
@@ -7,6 +7,8 @@ on:
 jobs:
   publish_release_draft:
     runs-on: ubuntu-latest
+    if: github.repository == 'jellyfin/jellyfin-plugin-playbackreporting'
+    
     steps:
       - name: Get version from GITHUB_REF
         id: get-version

--- a/.github/workflows/update-release-draft.yml
+++ b/.github/workflows/update-release-draft.yml
@@ -9,6 +9,8 @@ on:
 jobs:
   update_release_draft:
     runs-on: ubuntu-latest
+    if: github.repository == 'jellyfin/jellyfin-plugin-playbackreporting'
+    
     steps:
       # Drafts your next Release notes as Pull Requests are merged into "master"
       - uses: release-drafter/release-drafter@v5.15.0

--- a/README.md
+++ b/README.md
@@ -2,14 +2,14 @@
 <h3 align="center">Part of the <a href="https://jellyfin.org">Jellyfin Project</a></h3>
 
 <p align="center">
-<img alt="Logo Banner" src="https://raw.githubusercontent.com/jellyfin/jellyfin-ux/master/branding/SVG/banner-logo-solid.svg?sanitize=true"/>
+<img alt="Plugin Banner" src="https://raw.githubusercontent.com/jellyfin/jellyfin-ux/master/plugins/SVG/jellyfin-plugin-playbackreporting.svg?sanitize=true"/>
 <br/>
 <br/>
 <a href="https://github.com/jellyfin/jellyfin-plugin-playbackreporting/actions?query=workflow%3A%22Test+Build+Plugin%22">
 <img alt="GitHub Workflow Status" src="https://img.shields.io/github/workflow/status/jellyfin/jellyfin-plugin-playbackreporting/Test%20Build%20Plugin.svg">
 </a>
 <a href="https://github.com/jellyfin/jellyfin-plugin-playbackreporting">
-<img alt="MIT License" src="https://img.shields.io/github/license/jellyfin/jellyfin-plugin-playbackreporting.svg"/>
+<img alt="GPLv3 License" src="https://img.shields.io/github/license/jellyfin/jellyfin-plugin-playbackreporting.svg"/>
 </a>
 <a href="https://github.com/jellyfin/jellyfin-plugin-playbackreporting/releases">
 <img alt="Current Release" src="https://img.shields.io/github/release/jellyfin/jellyfin-plugin-playbackreporting.svg"/>
@@ -18,19 +18,34 @@
 
 ## About
 
-The Jellyfin Playback Reporting plugin enables the collection and display of user and media activity on your server.
+This plugin enables the collection and visualization of user and media activity on your server.
 This information can be viewed as a multitude of different graphs, and can also be queried straight from the Jellyfin database.
 
-## Build & Installation Process
+## Installation
 
-1. Clone this repository
+[See the official documentation for install instructions](https://jellyfin.org/docs/general/server/plugins/index.html#installing).
 
-2. Ensure you have .NET Core SDK set up and installed
+## Build
 
-3. Build the plugin with your favorite IDE or the `dotnet` command:
+1. To build this plugin you will need [.Net 5.x](https://dotnet.microsoft.com/download/dotnet/5.0).
 
-```
-dotnet publish --configuration Release --output bin
-```
+2. Build plugin with following command
+  ```
+  dotnet publish --configuration Release --output bin
+  ```
 
-4. Place the resulting `Jellyfin.Plugin.PlaybackReporting.dll` file in a folder called `plugins/` inside your Jellyfin data directory
+3. Place the dll-file in the `plugins/playbackreporting` folder (you might need to create the folders) of your JF install
+
+## Releasing
+
+To release the plugin we recommend [JPRM](https://github.com/oddstr13/jellyfin-plugin-repository-manager) that will build and package the plugin.
+For additional context and for how to add the packaged plugin zip to a plugin manifest see the [JPRM documentation](https://github.com/oddstr13/jellyfin-plugin-repository-manager) for more info.
+
+## Contributing
+
+We welcome all contributions and pull requests! If you have a larger feature in mind please open an issue so we can discuss the implementation before you start.
+In general refer to our [contributing guidelines](https://github.com/jellyfin/.github/blob/master/CONTRIBUTING.md) for further information.
+
+## Licence
+
+This plugins code and packages are distributed under the GPLv3 License. See [LICENSE](./LICENSE) for more information.

--- a/build.yaml
+++ b/build.yaml
@@ -1,6 +1,7 @@
 ---
 name: "Playback Reporting"
 guid: "5c534381-91a3-43cb-907a-35aa02eb9d2c"
+imageUrl: "https://repo.jellyfin.org/releases/plugin/images/jellyfin-plugin-playbackreporting.png"
 version: "10.0.0.0"
 targetAbi: "10.7.0.0"
 framework: net5.0
@@ -9,7 +10,7 @@ overview: "Collect and show user play statistics"
 description: "Collect and show user play statistics"
 category: "General"
 artifacts:
-- "Jellyfin.Plugin.PlaybackReporting.dll"
-changelog: >
+  - "Jellyfin.Plugin.PlaybackReporting.dll"
+changelog: |
   * Fix query to PlayActivity endpoint on User Playback Report (#35) @Stampede10343
   * Feature/client timezone awareness (#37) @Stampede10343


### PR DESCRIPTION
* applies some smaller improvements to workflows
* updates readme with plugin-image
* adds plugin `imageUrl` to build.yaml

Merge Checklist:

* [x] either manually or via CI add plugin-images to [repo.jellyfin.org](https://repo.jellyfin.org/releases/plugin/)
* [x] ensure the plugin png is present within the plugin directory with the correct name on `repo.jellyfin.org`