### PR TITLE
Keep all avatars the same dimension

### DIFF
--- a/Jellyfin.Plugin.PlaybackReporting/Pages/user_report.js
+++ b/Jellyfin.Plugin.PlaybackReporting/Pages/user_report.js
@@ -105,7 +105,7 @@ const getConfigurationPageUrl = (name) => {
                             user_image = window.ApiClient.getUrl(user_image);
                         }                      
 
-                        row_html += "<td><img src='" + user_image + "' width='50px' style='background-color: black;'></td>";
+                        row_html += "<td><img src='" + user_image + "' width='50px' height='50px' style='background-color: black; object-fit: cover;'></td>";
                         row_html += "<td>" + user_info.user_name + "</td>";
                         row_html += "<td>" + user_info.last_seen + "</td>";
                         row_html += "<td>" + user_info.item_name + "</td>";


### PR DESCRIPTION
Previously if the profile picture was rectangular, the width would have been 50px, however the height would be bigger - according to its aspect ratio. This enforces 50px X 50px avatars, giving a cleaner aesthetic.