### PR TITLE
Order default query usefully & checkbox by default

### DIFF
--- a/Jellyfin.Plugin.PlaybackReporting/Pages/custom_query.html
+++ b/Jellyfin.Plugin.PlaybackReporting/Pages/custom_query.html
@@ -11,11 +11,12 @@
 			<textarea id="custom_query_text" style="width: 98%; height:75px">
 SELECT ROWID, * 
 FROM PlaybackActivity 
+ORDER BY rowid DESC 
 LIMIT 10
 			</textarea>
 			<br />
 			<br />
-			<input type='checkbox' id="replace_userid"> Replace UserId with UserName<br />
+			<input type='checkbox' id="replace_userid" checked="checked"> Replace UserId with UserName<br />
 			<br />
 			<button id="run_custom_query">Run</button>
 


### PR DESCRIPTION
* Right now it shows the first 10 rows from Jellyfin's inception.  This information is rarely useful.  Sort in descending order in the default query, which would be more likely to be a useful query.
* By default check the change IDs to user IDs.  The internal UID is generally useless to the end administrator.