### PR TITLE
Use LastUpdated Time Instead of Current Time for missing Stop event

### DIFF
--- a/Jellyfin.Plugin.PlaybackReporting/Data/PlaybackTracker.cs
+++ b/Jellyfin.Plugin.PlaybackReporting/Data/PlaybackTracker.cs
@@ -100,7 +100,7 @@ namespace Jellyfin.Plugin.PlaybackReporting.Data
                 {
                     events.Add(e);
                 }
-                KeyValuePair<DateTime, ActionType> stop_event = new KeyValuePair<DateTime, ActionType>(DateTime.Now, ActionType.STOP);
+                KeyValuePair<DateTime, ActionType> stop_event = new KeyValuePair<DateTime, ActionType>(LastUpdated, ActionType.STOP);
                 events.Add(stop_event);
             }
             else


### PR DESCRIPTION
Potentially Fixes #69 and #81.

As far as i can tell, the above issues happen due to misbehaving Clients and or a Bad Connection to The Server, Resulting in very long and Unrealistic Play times being Recorded:
![image](https://github.com/jellyfin/jellyfin-plugin-playbackreporting/assets/12772447/8f481072-dc88-4067-9c6a-50838e5ecd33)

The PlayBack Tracker is identified using the user id, device id and item id combined. Sometimes for whatever reason it seems that the SessionManager_PlaybackStop function does not get called when playback stops and the playback tracker does not get removed and no Stop event is added to the PlayBack Trackers log.

If the Server is then not restarted and the User starts a new playback of the same item on the same device some time later, the generated PlayBack Tracker identifier is the same and we run into this condition https://github.com/jellyfin/jellyfin-plugin-playbackreporting/blob/8bb1d7a2108400631390ee71f631112b5a1899eb/Jellyfin.Plugin.PlaybackReporting/EventMonitorEntryPoint.cs#L149C18-L149C19 (Can be spotted in the logs if triggered with the Message "Existing tracker found!") This triggers a cleanup of the existing Playback Tracker before starting a new one for the new Playback. The Cleanup Calls the track.CalculateDuration function to Calculate the Final duration of the Play. This function checks if the Last Event in its log is a Stop Event (which it isn't since SessionManager_PlaybackStop was never called which would normally generate this event) and appends one with the current time as the end time if it is missing.

This PR Changes the Time Used for the Generated Stop Event to be the LastUpdated Time which gets set every time SessionManager_PlaybackProgress gets called. This should be way more accurate than the current time.