### PR TITLE
Fix database connection disposal on server shutdown

### DIFF
--- a/Jellyfin.Plugin.PlaybackReporting/Data/IActivityRepository.cs
+++ b/Jellyfin.Plugin.PlaybackReporting/Data/IActivityRepository.cs
@@ -19,7 +19,7 @@ using System.Collections.Generic;
 
 namespace Jellyfin.Plugin.PlaybackReporting.Data
 {
-    public interface IActivityRepository
+    public interface IActivityRepository : IDisposable
     {
         int RemoveUnknownUsers(List<string> known_user_ids);
         void ManageUserList(string action, string id);

--- a/Jellyfin.Plugin.PlaybackReporting/EventMonitorEntryPoint.cs
+++ b/Jellyfin.Plugin.PlaybackReporting/EventMonitorEntryPoint.cs
@@ -34,7 +34,7 @@ using Microsoft.Extensions.Logging;
 
 namespace Jellyfin.Plugin.PlaybackReporting
 {
-    public class EventMonitorEntryPoint : IHostedService
+    public class EventMonitorEntryPoint : IHostedService, IDisposable
     {
         private readonly ISessionManager _sessionManager;
         private readonly IServerConfigurationManager _config;
@@ -367,6 +367,20 @@ namespace Jellyfin.Plugin.PlaybackReporting
             _sessionManager.PlaybackProgress -= SessionManager_PlaybackProgress;
 
             return Task.CompletedTask;
+        }
+
+        public void Dispose()
+        {
+            if (_repository != null)
+            {
+                _repository.Dispose();
+                _repository = null;
+            }
+        }
+
+        ~EventMonitorEntryPoint()
+        {
+            Dispose();
         }
     }
 }

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ This information can be viewed as a multitude of different graphs, and can also 
 
 ## Build
 
-1. To build this plugin you will need [.Net 5.x](https://dotnet.microsoft.com/download/dotnet/5.0).
+1. To build this plugin you will need [.Net 8.x](https://dotnet.microsoft.com/download/dotnet/8.0).
 
 2. Build plugin with following command
   ```


### PR DESCRIPTION
This PR aims to fix:
-  https://github.com/jellyfin/jellyfin-plugin-playbackreporting/issues/89

* `Jellyfin.Plugin.PlaybackReporting/Data/IActivityRepository.cs`: Implemented the `IDisposable` interface for the `IActivityRepository` to ensure proper resource cleanup and allow explicit calling of the Dispose method from the finalizer of `EventMonitorEntryPoint`.
* `Jellyfin.Plugin.PlaybackReporting/EventMonitorEntryPoint.cs`: Implemented the `IDisposable` interface and added a finalizer to the `EventMonitorEntryPoint` class to definetively ensure that the db connection is closed upon server shutdown.  
* `README.md`: updated the .NET SDK requirements
  
I've tested the fix on a Mac Mini M4 and don't have this issue anymore.

resolves #89

