### PR TITLE
Improve Timezone Handling and Fix End Date Picker

### DIFF
--- a/Jellyfin.Plugin.PlaybackReporting/Pages/breakdown_report.js
+++ b/Jellyfin.Plugin.PlaybackReporting/Pages/breakdown_report.js
@@ -276,7 +276,7 @@ const getConfigurationPageUrl = (name) => {
                     const timezoneOffset = -(new Date().getTimezoneOffset() / 60);
 
                     // build user chart
-                    var url = "user_usage_stats/UserId/BreakdownReport?days=" + days + "&end_date=" + end_date.value + "&stamp=" + new Date().getTime() + "&timezoneOffset=" + timezoneOffset;
+                    var url = "user_usage_stats/UserId/BreakdownReport?days=" + days + "&endDate=" + end_date.value + "&stamp=" + new Date().getTime() + "&timezoneOffset=" + timezoneOffset;
                     url = window.ApiClient.getUrl(url);
                     window.ApiClient.getUserActivity(url).then(function (data) {
                         //alert("Loaded Data: " + JSON.stringify(usage_data));
@@ -284,7 +284,7 @@ const getConfigurationPageUrl = (name) => {
                     });
 
                     // build ItemType chart
-                    var url = "user_usage_stats/ItemType/BreakdownReport?days=" + days + "&end_date=" + end_date.value + "&stamp=" + new Date().getTime() + "&timezoneOffset=" + timezoneOffset;
+                    var url = "user_usage_stats/ItemType/BreakdownReport?days=" + days + "&endDate=" + end_date.value + "&stamp=" + new Date().getTime() + "&timezoneOffset=" + timezoneOffset;
                     url = window.ApiClient.getUrl(url);
                     window.ApiClient.getUserActivity(url).then(function (data) {
                         //alert("Loaded Data: " + JSON.stringify(usage_data));
@@ -292,7 +292,7 @@ const getConfigurationPageUrl = (name) => {
                     });
 
                     // build PlaybackMethod chart
-                    var url = "user_usage_stats/PlaybackMethod/BreakdownReport?days=" + days + "&end_date=" + end_date.value + "&stamp=" + new Date().getTime() + "&timezoneOffset=" + timezoneOffset;
+                    var url = "user_usage_stats/PlaybackMethod/BreakdownReport?days=" + days + "&endDate=" + end_date.value + "&stamp=" + new Date().getTime() + "&timezoneOffset=" + timezoneOffset;
                     url = window.ApiClient.getUrl(url);
                     window.ApiClient.getUserActivity(url).then(function (data) {
                         //alert("Loaded Data: " + JSON.stringify(usage_data));
@@ -300,7 +300,7 @@ const getConfigurationPageUrl = (name) => {
                     });
 
                     // build ClientName chart
-                    var url = "user_usage_stats/ClientName/BreakdownReport?days=" + days + "&end_date=" + end_date.value + "&stamp=" + new Date().getTime() + "&timezoneOffset=" + timezoneOffset;
+                    var url = "user_usage_stats/ClientName/BreakdownReport?days=" + days + "&endDate=" + end_date.value + "&stamp=" + new Date().getTime() + "&timezoneOffset=" + timezoneOffset;
                     url = window.ApiClient.getUrl(url);
                     window.ApiClient.getUserActivity(url).then(function (data) {
                         //alert("Loaded Data: " + JSON.stringify(usage_data));
@@ -308,7 +308,7 @@ const getConfigurationPageUrl = (name) => {
                     });
 
                     // build DeviceName chart
-                    var url = "user_usage_stats/DeviceName/BreakdownReport?days=" + days + "&end_date=" + end_date.value + "&stamp=" + new Date().getTime() + "&timezoneOffset=" + timezoneOffset;
+                    var url = "user_usage_stats/DeviceName/BreakdownReport?days=" + days + "&endDate=" + end_date.value + "&stamp=" + new Date().getTime() + "&timezoneOffset=" + timezoneOffset;
                     url = window.ApiClient.getUrl(url);
                     window.ApiClient.getUserActivity(url).then(function (data) {
                         //alert("Loaded Data: " + JSON.stringify(usage_data));
@@ -316,7 +316,7 @@ const getConfigurationPageUrl = (name) => {
                     });
 
                     // build TvShows chart
-                    var url = "user_usage_stats/GetTvShowsReport?days=" + days + "&end_date=" + end_date.value + "&stamp=" + new Date().getTime() + "&timezoneOffset=" + timezoneOffset;
+                    var url = "user_usage_stats/GetTvShowsReport?days=" + days + "&endDate=" + end_date.value + "&stamp=" + new Date().getTime() + "&timezoneOffset=" + timezoneOffset;
                     url = window.ApiClient.getUrl(url);
                     window.ApiClient.getUserActivity(url).then(function (data) {
                         //alert("Loaded Data: " + JSON.stringify(usage_data));
@@ -324,7 +324,7 @@ const getConfigurationPageUrl = (name) => {
                     });
 
                     // build Movies chart
-                    var url = "user_usage_stats/MoviesReport?days=" + days + "&end_date=" + end_date.value + "&stamp=" + new Date().getTime() + "&timezoneOffset=" + timezoneOffset;
+                    var url = "user_usage_stats/MoviesReport?days=" + days + "&endDate=" + end_date.value + "&stamp=" + new Date().getTime() + "&timezoneOffset=" + timezoneOffset;
                     url = window.ApiClient.getUrl(url);
                     window.ApiClient.getUserActivity(url).then(function (data) {
                         //alert("Loaded Data: " + JSON.stringify(usage_data));

--- a/Jellyfin.Plugin.PlaybackReporting/Pages/duration_histogram_report.js
+++ b/Jellyfin.Plugin.PlaybackReporting/Pages/duration_histogram_report.js
@@ -209,7 +209,7 @@ const getConfigurationPageUrl = (name) => {
                         //Set days filter to 50 years if 'all' option is selected.
                         if (days == -7) days = 18250;
 
-                        var url = "user_usage_stats/DurationHistogramReport?days=" + days + "&end_date=" + end_date.value + "&filter=" + filter.join(",") + "&stamp=" + new Date().getTime();
+                        var url = "user_usage_stats/DurationHistogramReport?days=" + days + "&endDate=" + end_date.value + "&filter=" + filter.join(",") + "&stamp=" + new Date().getTime();
                         url = window.ApiClient.getUrl(url);
                         window.ApiClient.getUserActivity(url).then(function (usage_data) {
                             //alert("Loaded Data: " + JSON.stringify(usage_data));

--- a/Jellyfin.Plugin.PlaybackReporting/Pages/hourly_usage_report.js
+++ b/Jellyfin.Plugin.PlaybackReporting/Pages/hourly_usage_report.js
@@ -412,7 +412,7 @@ const getConfigurationPageUrl = (name) => {
                         if (days == -7) days = 18250;
 
                         const timezoneOffset = -(new Date().getTimezoneOffset() / 60);
-                        var url = "user_usage_stats/HourlyReport?days=" + days + "&end_date=" + end_date.value + "&filter=" + filter.join(",") + "&stamp=" + new Date().getTime() + "&timezoneOffset=" + timezoneOffset;
+                        var url = "user_usage_stats/HourlyReport?days=" + days + "&endDate=" + end_date.value + "&filter=" + filter.join(",") + "&stamp=" + new Date().getTime() + "&timezoneOffset=" + timezoneOffset;
                         url = window.ApiClient.getUrl(url);
                         window.ApiClient.getUserActivity(url).then(function (usage_data) {
                             //alert("Loaded Data: " + JSON.stringify(usage_data));

--- a/Jellyfin.Plugin.PlaybackReporting/Pages/user_report.js
+++ b/Jellyfin.Plugin.PlaybackReporting/Pages/user_report.js
@@ -87,7 +87,7 @@ const getConfigurationPageUrl = (name) => {
                 //Set days filter to 50 years if 'all' option is selected.
                 if (days == -7) days = 18250;
 
-                var url = "user_usage_stats/user_activity?days=" + days + "&end_date=" + end_date.value + "&stamp=" + new Date().getTime();
+                var url = "user_usage_stats/user_activity?days=" + days + "&endDate=" + end_date.value + "&stamp=" + new Date().getTime();
                 url = window.ApiClient.getUrl(url);
                 window.ApiClient.getUserActivity(url).then(function (user_data) {
                     console.log("usage_data: " + JSON.stringify(user_data));


### PR DESCRIPTION
This pull request introduces several changes to the `Jellyfin.Plugin.PlaybackReporting` plugin, primarily focusing on handling user-server timezone offsets more accurately and fixing the end date date picker across various reports.

### Timezone Handling Improvements
* Added a new method, `CalculateUserServerTimezoneOffset`, to compute the timezone offset between the user and the server. This is necessary because the plugin currently saves playback reporting database entries using the server's local timezone (instead of UTC). Therefore, a timezone offset is only needed if the timezones of the user and server differ.
* Although saving the entries directly in UTC would be the cleaner approach, changing this now would be a breaking change for all data already saved. I wanted to avoid this.
* Updated the `GetUsageForUser`, `GetUsageForDays`, `GetHourlyUsageReport`, `GetBreakdownReport`, `GetTvShowReport`, `GetMoviesReport`, and `GetUserReport` methods to use the new timezone offset calculation method.

### Invalid URL Parameter
Fixed the URL parameter `end_date`/`endDate` in various JavaScript API calls, which caused the end date date picker not to work.


resolves https://github.com/jellyfin/jellyfin-plugin-playbackreporting/issues/47
resolves https://github.com/jellyfin/jellyfin-plugin-playbackreporting/issues/31
resolves https://github.com/jellyfin/jellyfin-plugin-playbackreporting/issues/94