### PR TITLE
Add explicit database init/shutdown for better connection disposal

### DIFF
--- a/Jellyfin.Plugin.PlaybackReporting/Data/BaseSqliteRepository.cs
+++ b/Jellyfin.Plugin.PlaybackReporting/Data/BaseSqliteRepository.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
 Copyright(C) 2018
 
 This program is free software: you can redistribute it and/or modify
@@ -62,6 +62,7 @@ namespace Jellyfin.Plugin.PlaybackReporting.Data
             _ = raw.sqlite3_enable_shared_cache(1);
 
             ThreadSafeMode = raw.sqlite3_threadsafe();
+            _ = raw.sqlite3_initialize();
         }
 
         private static bool _versionLogged;
@@ -156,11 +157,7 @@ namespace Jellyfin.Plugin.PlaybackReporting.Data
                 }
                 catch
                 {
-                    using (db)
-                    {
-
-                    }
-
+                    db.Dispose();
                     throw;
                 }
 
@@ -194,8 +191,9 @@ namespace Jellyfin.Plugin.PlaybackReporting.Data
         protected virtual void Dispose(bool dispose)
         {
             if (dispose)
-            {
+            {   
                 DisposeConnection();
+                _ = raw.sqlite3_shutdown();
             }
         }
 
@@ -215,8 +213,6 @@ namespace Jellyfin.Plugin.PlaybackReporting.Data
                             }
                             _connection = null;
                         }
-
-                        CloseConnection();
                     }
                 }
             }
@@ -226,10 +222,6 @@ namespace Jellyfin.Plugin.PlaybackReporting.Data
             }
         }
 
-        protected virtual void CloseConnection()
-        {
-
-        }
     }
 
     public static class ReaderWriterLockSlimExtensions

--- a/Jellyfin.Plugin.PlaybackReporting/Data/ManagedConnection.cs
+++ b/Jellyfin.Plugin.PlaybackReporting/Data/ManagedConnection.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
 Copyright(C) 2018
 
 This program is free software: you can redistribute it and/or modify
@@ -59,10 +59,7 @@ namespace Jellyfin.Plugin.PlaybackReporting.Data
 
         public void Close()
         {
-            using (_db)
-            {
-
-            }
+            _db.Dispose();
         }
 
         public void Dispose()


### PR DESCRIPTION
This pull request is a successor to PR #98 
While the previous PR already showed an improvement it came up during long term testing that there are still cases where the datbase locks up and is readonly.
The PR reworks the Dispose methods to better comply with the standard .NET pattern and as most important change introduces eplicit initialization and shutdown of the SQLite database which intends to ultimatively solve the "readonly" upon restart problem.

Improvements to the database connection disposal:

* [`Jellyfin.Plugin.PlaybackReporting/Data/BaseSqliteRepository.cs`](diffhunk://#diff-7614ab7d67f054725e4ef207bdbad3a854997f1b6095b4b4040c19604eef6bb8R65): Added `_ = raw.sqlite3_initialize();` to the static constructor and `_ = raw.sqlite3_shutdown();` to the `Dispose` method

* [`Jellyfin.Plugin.PlaybackReporting/EventMonitorEntryPoint.cs`](diffhunk://#diff-0a5bb7a2fa5bffd5d01c587b65a11aa3337c0444e0f8577f7bf95b71d69aaf0dR43): Added a flag `_disposedFlag` and updated the `Dispose` method to allow a differentiation between managed and and unmanaged ressources and with this comply to the standard .NET disposal pattern.  Also, added a check in `StopAsync` to dispose of the repository if it is not null.

Code cleanup:

* [`Jellyfin.Plugin.PlaybackReporting/Data/BaseSqliteRepository.cs`](diffhunk://#diff-7614ab7d67f054725e4ef207bdbad3a854997f1b6095b4b4040c19604eef6bb8L218-L219): Removed the unused `CloseConnection` method and its call within `DisposeConnection`. 
* [`Jellyfin.Plugin.PlaybackReporting/Data/ManagedConnection.cs`](diffhunk://#diff-e11b0538053addc80c5a6274fc0de1c95daa1a71122b12ac7c799e5cee6afafeL62-R62): Replaced the empty `using (_db)` pattern with a direct call to `_db.Dispose();` instead to improve readability.
* [`Jellyfin.Plugin.PlaybackReporting/Data/BaseSqliteRepository.cs`](diffhunk://#diff-7614ab7d67f054725e4ef207bdbad3a854997f1b6095b4b4040c19604eef6bb8L159-R160): Replaced the empty `using (db)` pattern with a direct call to `db.Dispose();` instead to improve readability.
* `various classes`: Removed unused imports

resolves #96 