### PR TITLE
fix: require admin privileges to access API

### DIFF
--- a/Jellyfin.Plugin.PlaybackReporting/Api/PlaybackReportingActivityController.cs
+++ b/Jellyfin.Plugin.PlaybackReporting/Api/PlaybackReportingActivityController.cs
@@ -21,6 +21,7 @@ using System.Linq;
 using System.Net.Mime;
 using Jellyfin.Data.Entities;
 using Jellyfin.Plugin.PlaybackReporting.Data;
+using MediaBrowser.Common.Api;
 using MediaBrowser.Controller.Configuration;
 using MediaBrowser.Controller.Library;
 using MediaBrowser.Model.IO;
@@ -32,7 +33,7 @@ using Microsoft.Extensions.Logging;
 namespace Jellyfin.Plugin.PlaybackReporting.Api
 {
     [ApiController]
-    [Authorize]
+    [Authorize(Policy = Policies.RequiresElevation)]
     [Route("user_usage_stats")]
     [Produces(MediaTypeNames.Application.Json)]
     public class PlaybackReportingActivityController : ControllerBase


### PR DESCRIPTION
I have just reviewed the security of my Jellyfin server and figured out that the Playback reporting plugin offers full access to its data to any user, not just administrators.

Therefore I updated the permissions for the playback reporting API. I have already deployed it on my server and it works fine.