### PR TITLE
Redesign pages, add CSS where it is missing

### DIFF
--- a/Jellyfin.Plugin.PlaybackReporting/Jellyfin.Plugin.PlaybackReporting.csproj
+++ b/Jellyfin.Plugin.PlaybackReporting/Jellyfin.Plugin.PlaybackReporting.csproj
@@ -11,8 +11,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Jellyfin.Data" Version="10.*-*" />
-    <PackageReference Include="Jellyfin.Controller" Version="10.*-*" />
+    <PackageReference Include="Jellyfin.Data" Version="10.10.7" />
+    <PackageReference Include="Jellyfin.Controller" Version="10.10.7" />
     <PackageReference Include="SQLitePCL.pretty.netstandard" Version="3.1.0" />
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>

--- a/Jellyfin.Plugin.PlaybackReporting/Jellyfin.Plugin.PlaybackReporting.csproj
+++ b/Jellyfin.Plugin.PlaybackReporting/Jellyfin.Plugin.PlaybackReporting.csproj
@@ -11,8 +11,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Jellyfin.Data" Version="10.10.7" />
-    <PackageReference Include="Jellyfin.Controller" Version="10.10.7" />
+    <PackageReference Include="Jellyfin.Data" Version="10.*-*" />
+    <PackageReference Include="Jellyfin.Controller" Version="10.*-*" />
     <PackageReference Include="SQLitePCL.pretty.netstandard" Version="3.1.0" />
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>

--- a/Jellyfin.Plugin.PlaybackReporting/Pages/breakdown_report.html
+++ b/Jellyfin.Plugin.PlaybackReporting/Pages/breakdown_report.html
@@ -5,33 +5,39 @@
 		<div class="content-primary"  style="overflow-x: scroll;">
 			<h2>Breakdown Report</h2>
 
-			<table style="border: 1px solid black; padding: 1px;" cellpadding="5" cellspacing="5">
+			<table style="padding: 1px;margin:0;" cellpadding="5" cellspacing="5" class="paperList">
 				<tr>
 					<td>
 						End Date:
 					</td>
 					<td>
-						<input type="date" id="end_date" />
+						<input type="date" id="end_date" style="padding: .5em;" class="emby-select-withcolor emby-select"/>
 					</td>
 					<td>
 						Weeks:
 					</td>
 					<td>
-						<select id="weeks">
-							<option value="1">1</option>
-							<option value="2">2</option>
-							<option value="3">3</option>
-							<option value="4" selected>4</option>
-							<option value="5">5</option>
-							<option value="6">6</option>
-							<option value="7">7</option>
-							<option value="8">8</option>
-							<option value="9">9</option>
-							<option value="10">10</option>
-							<option value="11">11</option>
-							<option value="12">12</option>
-							<option value="-1">All</option>
-						</select>
+						<div class="selectContainer" style="margin:0;">
+							<select is="emby-select" id="weeks" class="emby-select-withcolor emby-select">
+								<option value="1">1</option>
+								<option value="2">2</option>
+								<option value="3">3</option>
+								<option value="4" selected>4</option>
+								<option value="5">5</option>
+								<option value="6">6</option>
+								<option value="7">7</option>
+								<option value="8">8</option>
+								<option value="9">9</option>
+								<option value="10">10</option>
+								<option value="11">11</option>
+								<option value="12">12</option>
+								<option value="-1">All</option>
+							</select>
+							<div class="selectArrowContainer">
+								<div style="visibility:hidden;display:none;">0</div>
+								<span class="selectArrow material-icons keyboard_arrow_down" aria-hidden="true" style="margin-top: 0.2em;"></span>
+							</div>
+						</div>
 					</td>
 				</tr>
 			</table>

--- a/Jellyfin.Plugin.PlaybackReporting/Pages/custom_query.html
+++ b/Jellyfin.Plugin.PlaybackReporting/Pages/custom_query.html
@@ -6,19 +6,29 @@
 		<div class="content-primary" style="overflow-x: scroll;">
 			<h2>Custom Query Report</h2>
 
-
-			<h3>Custom SQL Query</h3>
-			<textarea id="custom_query_text" style="width: 98%; height:75px">
+			<div class="inputContainer"> 
+				<label class="textareaLabel textareaLabelUnfocused" for="custom_query_text">Custom SQL Query</label>
+				<textarea is="emby-textarea" id="custom_query_text" label="Custom SQL Query" class="textarea-mono emby-textarea" style="width: 100%; height:175px; margin: 15px 0;">
 SELECT ROWID, * 
 FROM PlaybackActivity 
 ORDER BY rowid DESC 
 LIMIT 10
-			</textarea>
-			<br />
-			<br />
-			<input type='checkbox' id="replace_userid" checked="checked"> Replace UserId with UserName<br />
-			<br />
-			<button id="run_custom_query">Run</button>
+</textarea> 
+				<div class="fieldDescription">Run a custom query to generate a report.</div> 
+			</div>
+
+			<div class="checkboxList paperList" style="padding:.5em 1em; margin-bottom: 1.8em;"> 
+				<label class="emby-checkbox-label"> 
+					<input type="checkbox" is="emby-checkbox" id="replace_userid" checked="checked" data-embycheckbox="true" class="emby-checkbox"> 
+					<span class="checkboxLabel">Replace UserId with UserName</span> 
+					<span class="checkboxOutline">
+						<span class="material-icons checkboxIcon checkboxIcon-checked check" aria-hidden="true"></span>
+						<span class="material-icons checkboxIcon checkboxIcon-unchecked " aria-hidden="true"></span>
+					</span>
+				</label> 
+			</div>
+
+			<button is="emby-button" id="run_custom_query" class="raised button-submit block emby-button" style="width: auto;"> <span>Run</span> </button>
 
 			<h3>Query Result</h3>
 			<div id="query_result_message"> </div>

--- a/Jellyfin.Plugin.PlaybackReporting/Pages/custom_query.html
+++ b/Jellyfin.Plugin.PlaybackReporting/Pages/custom_query.html
@@ -33,7 +33,7 @@ LIMIT 10
 			<h3>Query Result</h3>
 			<div id="query_result_message"> </div>
 
-			<div id="table_area_div" style="">
+			<div id="table_area_div">
 				<table cellpadding="4" id="custom_query_table" style="width:100%;">
 					<tbody class="resultBody" id="custom_query_results"></tbody>
 				</table>

--- a/Jellyfin.Plugin.PlaybackReporting/Pages/custom_query.html
+++ b/Jellyfin.Plugin.PlaybackReporting/Pages/custom_query.html
@@ -34,7 +34,7 @@ LIMIT 10
 			<div id="query_result_message"> </div>
 
 			<div id="table_area_div">
-				<table cellpadding="4" id="custom_query_table" style="width:100%;">
+				<table cellpadding="6" id="custom_query_table" style="width:100%;">
 					<tbody class="resultBody" id="custom_query_results"></tbody>
 				</table>
 			</div>

--- a/Jellyfin.Plugin.PlaybackReporting/Pages/custom_query.html
+++ b/Jellyfin.Plugin.PlaybackReporting/Pages/custom_query.html
@@ -38,7 +38,6 @@ LIMIT 10
 					<tbody class="resultBody" id="custom_query_results"></tbody>
 				</table>
 			</div>
-
 		</div>
 	</div>
 </div>

--- a/Jellyfin.Plugin.PlaybackReporting/Pages/custom_query.html
+++ b/Jellyfin.Plugin.PlaybackReporting/Pages/custom_query.html
@@ -34,7 +34,7 @@ LIMIT 10
 			<div id="query_result_message"> </div>
 
 			<div id="table_area_div" style="">
-				<table cellpadding="2" id="custom_query_table">
+				<table cellpadding="4" id="custom_query_table" style="width:100%;">
 					<tbody class="resultBody" id="custom_query_results"></tbody>
 				</table>
 			</div>

--- a/Jellyfin.Plugin.PlaybackReporting/Pages/duration_histogram_report.html
+++ b/Jellyfin.Plugin.PlaybackReporting/Pages/duration_histogram_report.html
@@ -5,33 +5,39 @@
 		<div class="content-primary" style="overflow-x: scroll;">
 			<h2>Playback Session Duration Report</h2>
 
-			<table style="border: 1px solid black; padding: 1px;" cellpadding="5" cellspacing="5">
+			<table style="padding: 1px;margin:0;" cellpadding="5" cellspacing="5" class="paperList">
 				<tr>
 					<td>
 						End Date:
 					</td>
 					<td>
-						<input type="date" id="end_date" />
+						<input type="date" id="end_date" style="padding: .5em;" class="emby-select-withcolor emby-select"/>
 					</td>
 					<td>
 						Weeks:
 					</td>
 					<td>
-						<select id="weeks">
-							<option value="1">1</option>
-							<option value="2">2</option>
-							<option value="3">3</option>
-							<option value="4" selected>4</option>
-							<option value="5">5</option>
-							<option value="6">6</option>
-							<option value="7">7</option>
-							<option value="8">8</option>
-							<option value="9">9</option>
-							<option value="10">10</option>
-							<option value="11">11</option>
-							<option value="12">12</option>
-							<option value="-1">All</option>
-						</select>
+						<div class="selectContainer" style="margin:0;">
+							<select is="emby-select" id="weeks" class="emby-select-withcolor emby-select">
+								<option value="1">1</option>
+								<option value="2">2</option>
+								<option value="3">3</option>
+								<option value="4" selected>4</option>
+								<option value="5">5</option>
+								<option value="6">6</option>
+								<option value="7">7</option>
+								<option value="8">8</option>
+								<option value="9">9</option>
+								<option value="10">10</option>
+								<option value="11">11</option>
+								<option value="12">12</option>
+								<option value="-1">All</option>
+							</select>
+							<div class="selectArrowContainer">
+								<div style="visibility:hidden;display:none;">0</div>
+								<span class="selectArrow material-icons keyboard_arrow_down" aria-hidden="true" style="margin-top: 0.2em;"></span>
+							</div>
+						</div>
 					</td>
 					<td>
 					<span id="filter_check_list"></span>

--- a/Jellyfin.Plugin.PlaybackReporting/Pages/duration_histogram_report.html
+++ b/Jellyfin.Plugin.PlaybackReporting/Pages/duration_histogram_report.html
@@ -43,7 +43,7 @@
 				</tr>
 			</table>
 			
-			<table style="padding: 1px;margin:0;" cellpadding="5" cellspacing="5" class="paperList">
+			<table style="padding: 4px;margin:0;" cellpadding="5" cellspacing="5" class="paperList">
 				<tr>
 					<td>
 						<span id="filter_check_list"></span>

--- a/Jellyfin.Plugin.PlaybackReporting/Pages/duration_histogram_report.html
+++ b/Jellyfin.Plugin.PlaybackReporting/Pages/duration_histogram_report.html
@@ -43,7 +43,7 @@
 				</tr>
 			</table>
 			
-			<table style="padding: 4px;margin:0;" cellpadding="5" cellspacing="5" class="paperList filter_check_list" >
+			<table style="padding: 4px;margin:10px 0;" cellpadding="5" cellspacing="5" class="paperList filter_check_list" >
 				<tr>
 					<td>
 						<span id="filter_check_list"></span>

--- a/Jellyfin.Plugin.PlaybackReporting/Pages/duration_histogram_report.html
+++ b/Jellyfin.Plugin.PlaybackReporting/Pages/duration_histogram_report.html
@@ -5,8 +5,7 @@
 		<div class="content-primary" style="overflow-x: scroll;">
 			<h2>Playback Session Duration Report</h2>
 
-			<style>table.filter_check_list { display: inline-block; }</style>
-			<table style="padding: 1px;margin:0;" cellpadding="5" cellspacing="5" class="paperList">
+			<table style="padding: 1px;margin:5px 0;display: inline-block;" cellpadding="5" cellspacing="5" class="paperList">
 				<tr>
 					<td>
 						End Date:
@@ -43,7 +42,7 @@
 				</tr>
 			</table>
 			
-			<table style="padding: 4px;margin:10px 0;" cellpadding="5" cellspacing="5" class="paperList filter_check_list" >
+			<table style="padding: 4px;margin:5px 0;display: inline-block;" cellpadding="5" cellspacing="5" class="paperList" >
 				<tr>
 					<td>
 						<span id="filter_check_list"></span>

--- a/Jellyfin.Plugin.PlaybackReporting/Pages/duration_histogram_report.html
+++ b/Jellyfin.Plugin.PlaybackReporting/Pages/duration_histogram_report.html
@@ -5,6 +5,7 @@
 		<div class="content-primary" style="overflow-x: scroll;">
 			<h2>Playback Session Duration Report</h2>
 
+			<style>table { display: inline-block; }</style>
 			<table style="padding: 1px;margin:0;" cellpadding="5" cellspacing="5" class="paperList">
 				<tr>
 					<td>
@@ -39,13 +40,17 @@
 							</div>
 						</div>
 					</td>
+				</tr>
+			</table>
+			
+			<table style="padding: 1px;margin:0;" cellpadding="5" cellspacing="5" class="paperList">
+				<tr>
 					<td>
-					<span id="filter_check_list"></span>
+						<span id="filter_check_list"></span>
 					</td>
 				</tr>
 			</table>
-			<span id="filter_check_list">
-			</span>
+
 			<br />
 
 			<div style="width: 75%; margin:0 auto; padding-top: 100px">

--- a/Jellyfin.Plugin.PlaybackReporting/Pages/duration_histogram_report.html
+++ b/Jellyfin.Plugin.PlaybackReporting/Pages/duration_histogram_report.html
@@ -5,7 +5,7 @@
 		<div class="content-primary" style="overflow-x: scroll;">
 			<h2>Playback Session Duration Report</h2>
 
-			<style>table { display: inline-block; }</style>
+			<style>table.filter_check_list { display: inline-block; }</style>
 			<table style="padding: 1px;margin:0;" cellpadding="5" cellspacing="5" class="paperList">
 				<tr>
 					<td>
@@ -43,7 +43,7 @@
 				</tr>
 			</table>
 			
-			<table style="padding: 4px;margin:0;" cellpadding="5" cellspacing="5" class="paperList">
+			<table style="padding: 4px;margin:0;" cellpadding="5" cellspacing="5" class="paperList filter_check_list" >
 				<tr>
 					<td>
 						<span id="filter_check_list"></span>

--- a/Jellyfin.Plugin.PlaybackReporting/Pages/duration_histogram_report.js
+++ b/Jellyfin.Plugin.PlaybackReporting/Pages/duration_histogram_report.js
@@ -175,7 +175,7 @@ const getConfigurationPageUrl = (name) => {
                     var filter_items = "";
                     for (var x1 = 0; x1 < filter_names.length; x1++) {
                         var filter_name_01 = filter_names[x1];
-                        filter_items += `<label class="emby-checkbox-label" style="width: 6em;line-height: 39px;">
+                        filter_items += `<label class="emby-checkbox-label" style="width: auto;line-height: 39px;padding-right: 10px;">
 							<input type="checkbox" is="emby-checkbox" id='media_type_filter_` + filter_name_01 + `' data_fileter_name='` + filter_name_01 + `' data-embycheckbox="true" checked class="emby-checkbox"> 
 							<span class="checkboxLabel">` + filter_name_01 + `</span> 
 							<span class="checkboxOutline">

--- a/Jellyfin.Plugin.PlaybackReporting/Pages/duration_histogram_report.js
+++ b/Jellyfin.Plugin.PlaybackReporting/Pages/duration_histogram_report.js
@@ -175,7 +175,14 @@ const getConfigurationPageUrl = (name) => {
                     var filter_items = "";
                     for (var x1 = 0; x1 < filter_names.length; x1++) {
                         var filter_name_01 = filter_names[x1];
-                        filter_items += "<input type='checkbox' id='media_type_filter_" + filter_name_01 + "' data_fileter_name='" + filter_name_01 + "' checked> " + filter_name_01 + " ";
+                        filter_items += `<label class="emby-checkbox-label" style="width: 6em;line-height: 39px;">
+							<input type="checkbox" is="emby-checkbox" id='media_type_filter_` + filter_name_01 + `' data_fileter_name='` + filter_name_01 + `' data-embycheckbox="true" checked class="emby-checkbox"> 
+							<span class="checkboxLabel">` + filter_name_01 + `</span> 
+							<span class="checkboxOutline">
+								<span class="material-icons checkboxIcon checkboxIcon-checked check" aria-hidden="true"></span>
+								<span class="material-icons checkboxIcon checkboxIcon-unchecked " aria-hidden="true"></span>
+							</span>
+						</label> `;
                     }
 
                     var filter_check_list = view.querySelector('#filter_check_list');

--- a/Jellyfin.Plugin.PlaybackReporting/Pages/hourly_usage_report.html
+++ b/Jellyfin.Plugin.PlaybackReporting/Pages/hourly_usage_report.html
@@ -42,7 +42,6 @@
 				</tr>
 			</table>
 
-
 			<table style="padding: 4px;margin:5px 0;display: inline-block;" cellpadding="5" cellspacing="5" class="paperList">
 				<tr>
 					<td>

--- a/Jellyfin.Plugin.PlaybackReporting/Pages/hourly_usage_report.html
+++ b/Jellyfin.Plugin.PlaybackReporting/Pages/hourly_usage_report.html
@@ -40,16 +40,13 @@
 						</div>
 					</td>
 				</tr>
-			</table>
-
-
-			<table style="padding: 1px;margin:0;" cellpadding="5" cellspacing="5" class="paperList">
 				<tr>
 					<td>
 						<span id="filter_check_list"></span>
 					</td>
 				</tr>
 			</table>
+
 			<br />
 
 			<div style="margin:0 auto; width: 75%; padding-top: 100px">

--- a/Jellyfin.Plugin.PlaybackReporting/Pages/hourly_usage_report.html
+++ b/Jellyfin.Plugin.PlaybackReporting/Pages/hourly_usage_report.html
@@ -4,7 +4,8 @@
 	<div data-role="content">
 		<div class="content-primary" style="overflow-x: scroll;">
 			<h2>Usage Report</h2>
-
+			
+			<style>table { display: inline-block; }</style>
 			<table style="padding: 1px;margin:0;" cellpadding="5" cellspacing="5" class="paperList">
 				<tr>
 					<td>

--- a/Jellyfin.Plugin.PlaybackReporting/Pages/hourly_usage_report.html
+++ b/Jellyfin.Plugin.PlaybackReporting/Pages/hourly_usage_report.html
@@ -41,6 +41,20 @@
 					</td>
 					<td>
 						<span id="filter_check_list"></span>
+
+
+
+						<label class="emby-checkbox-label" style="width: 6em;line-height: 39px;">
+							<input type="checkbox" is="emby-checkbox" id="chkQuickConnectAvailable" data-embycheckbox="true" checked class="emby-checkbox"> 
+							<span class="checkboxLabel">Movie</span> 
+							<span class="checkboxOutline">
+								<span class="material-icons checkboxIcon checkboxIcon-checked check" aria-hidden="true"></span>
+								<span class="material-icons checkboxIcon checkboxIcon-unchecked " aria-hidden="true"></span>
+							</span>
+						</label>
+
+
+
 					</td>
 				</tr>
 			</table>

--- a/Jellyfin.Plugin.PlaybackReporting/Pages/hourly_usage_report.html
+++ b/Jellyfin.Plugin.PlaybackReporting/Pages/hourly_usage_report.html
@@ -5,33 +5,39 @@
 		<div class="content-primary" style="overflow-x: scroll;">
 			<h2>Usage Report</h2>
 
-			<table style="border: 1px solid black; padding: 1px;" cellpadding="5" cellspacing="5">
+			<table style="padding: 1px;margin:0;" cellpadding="5" cellspacing="5" class="paperList">
 				<tr>
 					<td>
 						End Date:
 					</td>
 					<td>
-						<input type="date" id="end_date" />
+						<input type="date" id="end_date" style="padding: .5em;" class="emby-select-withcolor emby-select"/>
 					</td>
 					<td>
 						Weeks:
 					</td>
 					<td>
-						<select id="weeks">
-							<option value="1">1</option>
-							<option value="2">2</option>
-							<option value="3">3</option>
-							<option value="4" selected>4</option>
-							<option value="5">5</option>
-							<option value="6">6</option>
-							<option value="7">7</option>
-							<option value="8">8</option>
-							<option value="9">9</option>
-							<option value="10">10</option>
-							<option value="11">11</option>
-							<option value="12">12</option>
-							<option value="-1">All</option>
-						</select>
+						<div class="selectContainer" style="margin:0;">
+							<select is="emby-select" id="weeks" class="emby-select-withcolor emby-select">
+								<option value="1">1</option>
+								<option value="2">2</option>
+								<option value="3">3</option>
+								<option value="4" selected>4</option>
+								<option value="5">5</option>
+								<option value="6">6</option>
+								<option value="7">7</option>
+								<option value="8">8</option>
+								<option value="9">9</option>
+								<option value="10">10</option>
+								<option value="11">11</option>
+								<option value="12">12</option>
+								<option value="-1">All</option>
+							</select>
+							<div class="selectArrowContainer">
+								<div style="visibility:hidden;display:none;">0</div>
+								<span class="selectArrow material-icons keyboard_arrow_down" aria-hidden="true" style="margin-top: 0.2em;"></span>
+							</div>
+						</div>
 					</td>
 					<td>
 						<span id="filter_check_list"></span>

--- a/Jellyfin.Plugin.PlaybackReporting/Pages/hourly_usage_report.html
+++ b/Jellyfin.Plugin.PlaybackReporting/Pages/hourly_usage_report.html
@@ -39,22 +39,14 @@
 							</div>
 						</div>
 					</td>
+				</tr>
+			</table>
+
+
+			<table style="padding: 1px;margin:0;" cellpadding="5" cellspacing="5" class="paperList">
+				<tr>
 					<td>
 						<span id="filter_check_list"></span>
-
-
-
-						<label class="emby-checkbox-label" style="width: 6em;line-height: 39px;">
-							<input type="checkbox" is="emby-checkbox" id="chkQuickConnectAvailable" data-embycheckbox="true" checked class="emby-checkbox"> 
-							<span class="checkboxLabel">Movie</span> 
-							<span class="checkboxOutline">
-								<span class="material-icons checkboxIcon checkboxIcon-checked check" aria-hidden="true"></span>
-								<span class="material-icons checkboxIcon checkboxIcon-unchecked " aria-hidden="true"></span>
-							</span>
-						</label>
-
-
-
 					</td>
 				</tr>
 			</table>

--- a/Jellyfin.Plugin.PlaybackReporting/Pages/hourly_usage_report.html
+++ b/Jellyfin.Plugin.PlaybackReporting/Pages/hourly_usage_report.html
@@ -44,7 +44,7 @@
 			</table>
 
 
-			<table style="padding: 4px;margin:0;" cellpadding="5" cellspacing="5" class="paperList filter_check_list">
+			<table style="padding: 4px;margin:10px 0;" cellpadding="5" cellspacing="5" class="paperList filter_check_list">
 				<tr>
 					<td>
 						<span id="filter_check_list"></span>

--- a/Jellyfin.Plugin.PlaybackReporting/Pages/hourly_usage_report.html
+++ b/Jellyfin.Plugin.PlaybackReporting/Pages/hourly_usage_report.html
@@ -5,8 +5,7 @@
 		<div class="content-primary" style="overflow-x: scroll;">
 			<h2>Usage Report</h2>
 
-			<style>table.filter_check_list { display: inline-block; }</style>
-			<table style="padding: 1px;margin:0;" cellpadding="5" cellspacing="5" class="paperList">
+			<table style="padding: 1px;margin:5px 0;display: inline-block;" cellpadding="5" cellspacing="5" class="paperList">
 				<tr>
 					<td>
 						End Date:
@@ -44,7 +43,7 @@
 			</table>
 
 
-			<table style="padding: 4px;margin:10px 0;" cellpadding="5" cellspacing="5" class="paperList filter_check_list">
+			<table style="padding: 4px;margin:5px 0;display: inline-block;" cellpadding="5" cellspacing="5" class="paperList">
 				<tr>
 					<td>
 						<span id="filter_check_list"></span>

--- a/Jellyfin.Plugin.PlaybackReporting/Pages/hourly_usage_report.html
+++ b/Jellyfin.Plugin.PlaybackReporting/Pages/hourly_usage_report.html
@@ -40,13 +40,16 @@
 						</div>
 					</td>
 				</tr>
+			</table>
+
+
+			<table style="padding: 1px;margin:0;" cellpadding="5" cellspacing="5" class="paperList">
 				<tr>
 					<td>
 						<span id="filter_check_list"></span>
 					</td>
 				</tr>
 			</table>
-
 			<br />
 
 			<div style="margin:0 auto; width: 75%; padding-top: 100px">

--- a/Jellyfin.Plugin.PlaybackReporting/Pages/hourly_usage_report.html
+++ b/Jellyfin.Plugin.PlaybackReporting/Pages/hourly_usage_report.html
@@ -5,7 +5,7 @@
 		<div class="content-primary" style="overflow-x: scroll;">
 			<h2>Usage Report</h2>
 
-			<style>table { display: inline-block; }</style>
+			<style>table.filter_check_list { display: inline-block; }</style>
 			<table style="padding: 1px;margin:0;" cellpadding="5" cellspacing="5" class="paperList">
 				<tr>
 					<td>
@@ -44,7 +44,7 @@
 			</table>
 
 
-			<table style="padding: 4px;margin:0;" cellpadding="5" cellspacing="5" class="paperList">
+			<table style="padding: 4px;margin:0;" cellpadding="5" cellspacing="5" class="paperList filter_check_list">
 				<tr>
 					<td>
 						<span id="filter_check_list"></span>

--- a/Jellyfin.Plugin.PlaybackReporting/Pages/hourly_usage_report.html
+++ b/Jellyfin.Plugin.PlaybackReporting/Pages/hourly_usage_report.html
@@ -4,7 +4,7 @@
 	<div data-role="content">
 		<div class="content-primary" style="overflow-x: scroll;">
 			<h2>Usage Report</h2>
-			
+
 			<style>table { display: inline-block; }</style>
 			<table style="padding: 1px;margin:0;" cellpadding="5" cellspacing="5" class="paperList">
 				<tr>
@@ -44,7 +44,7 @@
 			</table>
 
 
-			<table style="padding: 1px;margin:0;" cellpadding="5" cellspacing="5" class="paperList">
+			<table style="padding: 4px;margin:0;" cellpadding="5" cellspacing="5" class="paperList">
 				<tr>
 					<td>
 						<span id="filter_check_list"></span>

--- a/Jellyfin.Plugin.PlaybackReporting/Pages/hourly_usage_report.js
+++ b/Jellyfin.Plugin.PlaybackReporting/Pages/hourly_usage_report.js
@@ -378,7 +378,7 @@ const getConfigurationPageUrl = (name) => {
                     for (var x1 = 0; x1 < filter_names.length; x1++) {
                         var filter_name_01 = filter_names[x1];
                         filter_items += `<label class="emby-checkbox-label" style="width: 6em;line-height: 39px;">
-							<input type="checkbox" is="emby-checkbox" id='media_type_filter_"` + filter_name_01 + `' data_fileter_name='` + filter_name_01 + `' data-embycheckbox="true" checked class="emby-checkbox"> 
+							<input type="checkbox" is="emby-checkbox" id='media_type_filter_` + filter_name_01 + `' data_fileter_name='` + filter_name_01 + `' data-embycheckbox="true" checked class="emby-checkbox"> 
 							<span class="checkboxLabel">` + filter_name_01 + `</span> 
 							<span class="checkboxOutline">
 								<span class="material-icons checkboxIcon checkboxIcon-checked check" aria-hidden="true"></span>

--- a/Jellyfin.Plugin.PlaybackReporting/Pages/hourly_usage_report.js
+++ b/Jellyfin.Plugin.PlaybackReporting/Pages/hourly_usage_report.js
@@ -377,7 +377,7 @@ const getConfigurationPageUrl = (name) => {
                     var filter_items = "";
                     for (var x1 = 0; x1 < filter_names.length; x1++) {
                         var filter_name_01 = filter_names[x1];
-                        filter_items += `<label class="emby-checkbox-label" style="width: 6em;line-height: 39px;">
+                        filter_items += `<label class="emby-checkbox-label" style="width: auto;line-height: 39px;padding-right: 10px;">
 							<input type="checkbox" is="emby-checkbox" id='media_type_filter_` + filter_name_01 + `' data_fileter_name='` + filter_name_01 + `' data-embycheckbox="true" checked class="emby-checkbox"> 
 							<span class="checkboxLabel">` + filter_name_01 + `</span> 
 							<span class="checkboxOutline">

--- a/Jellyfin.Plugin.PlaybackReporting/Pages/hourly_usage_report.js
+++ b/Jellyfin.Plugin.PlaybackReporting/Pages/hourly_usage_report.js
@@ -377,8 +377,7 @@ const getConfigurationPageUrl = (name) => {
                     var filter_items = "";
                     for (var x1 = 0; x1 < filter_names.length; x1++) {
                         var filter_name_01 = filter_names[x1];
-                        filter_items += `
-                        <label class="emby-checkbox-label" style="width: 6em;line-height: 39px;">
+                        filter_items += `<label class="emby-checkbox-label" style="width: 6em;line-height: 39px;">
 							<input type="checkbox" is="emby-checkbox" id='media_type_filter_"` + filter_name_01 + `' data_fileter_name='` + filter_name_01 + `' data-embycheckbox="true" checked class="emby-checkbox"> 
 							<span class="checkboxLabel">` + filter_name_01 + `</span> 
 							<span class="checkboxOutline">

--- a/Jellyfin.Plugin.PlaybackReporting/Pages/hourly_usage_report.js
+++ b/Jellyfin.Plugin.PlaybackReporting/Pages/hourly_usage_report.js
@@ -377,7 +377,15 @@ const getConfigurationPageUrl = (name) => {
                     var filter_items = "";
                     for (var x1 = 0; x1 < filter_names.length; x1++) {
                         var filter_name_01 = filter_names[x1];
-                        filter_items += "<input type='checkbox' id='media_type_filter_" + filter_name_01 + "' data_fileter_name='" + filter_name_01 + "' checked> " + filter_name_01 + " ";
+                        filter_items += `
+                        <label class="emby-checkbox-label" style="width: 6em;line-height: 39px;">
+							<input type="checkbox" is="emby-checkbox" id='media_type_filter_"` + filter_name_01 + `' data_fileter_name='` + filter_name_01 + `' data-embycheckbox="true" checked class="emby-checkbox"> 
+							<span class="checkboxLabel">` + filter_name_01 + `</span> 
+							<span class="checkboxOutline">
+								<span class="material-icons checkboxIcon checkboxIcon-checked check" aria-hidden="true"></span>
+								<span class="material-icons checkboxIcon checkboxIcon-unchecked " aria-hidden="true"></span>
+							</span>
+						</label> `;
                     }
 
                     var filter_check_list = view.querySelector('#filter_check_list');

--- a/Jellyfin.Plugin.PlaybackReporting/Pages/playback_report_settings.html
+++ b/Jellyfin.Plugin.PlaybackReporting/Pages/playback_report_settings.html
@@ -7,7 +7,7 @@
 			<h3>
 				<strong>Data Retention</strong>
 			</h3>
-			<div class="selectContainer">
+			<div class="selectContainer" style="width: 20em;">
 				<label class="selectLabel" for="max_data_age_select">Keep data for</label>
 				<select is="emby-select" id="max_data_age_select" label="Data Retention" class="emby-select-withcolor emby-select">
 					<option value="0">Clear All</option>
@@ -49,7 +49,7 @@
 				The saved backup data is in TSV format so can be loaded into other tools like Excel to build highly customised reports.
 			</p>
 			<p>
-				<button is="emby-button" id="set_backup_path" class="raised button-alt headerHelpButton emby-button" style="margin-left: 0 !important;">Set Backup Path</button>  Backup Path: <span id="backup_path_label"></span><br />
+				<button is="emby-button" id="set_backup_path" class="raised headerHelpButton emby-button" style="margin-left: 0 !important;">Set Backup Path</button>  Backup Path: <span id="backup_path_label"></span><br />
 			</p>
 
 

--- a/Jellyfin.Plugin.PlaybackReporting/Pages/playback_report_settings.html
+++ b/Jellyfin.Plugin.PlaybackReporting/Pages/playback_report_settings.html
@@ -37,9 +37,6 @@
 			</div>
 			<br />
 
-
-
-
 			<h3>
 				<strong>Backup</strong>
 			</h3>
@@ -51,7 +48,6 @@
 			<p>
 				<button is="emby-button" id="set_backup_path" class="raised headerHelpButton emby-button" style="margin-left: 0 !important;">Set Backup Path</button>  Backup Path: <span id="backup_path_label"></span><br />
 			</p>
-
 
 			<div class="selectContainer" style="width: 20em;">
 				<label class="selectLabel" for="files_to_keep">Backup files to keep</label>
@@ -73,9 +69,6 @@
 				<button id="load_backup_data" class="raised emby-button">Load Backup Data</button>
 			</p>
 			<br />
-
-
-
 
 			<h3>
 				<strong>Ignored User List</strong>

--- a/Jellyfin.Plugin.PlaybackReporting/Pages/playback_report_settings.html
+++ b/Jellyfin.Plugin.PlaybackReporting/Pages/playback_report_settings.html
@@ -2,31 +2,44 @@
 	 data-require="emby-button,emby-select,emby-checkbox"
 	 data-controller="__plugin/playback_report_settings.js">
 	<div data-role="content">
-		<div class="content-primary" style="overflow-x: scroll;">
+		<div class="content-primary" style="overflow-x: scroll;max-width: 60em;">
 			<h2>Playback Report Settings</h2>
 			<h3>
 				<strong>Data Retention</strong>
 			</h3>
-			<p>
-				Keep data for X time, this is used in the scheduled task to trim your data and keep only data within the requested time period.<br />
-				As you add and remove users from your system playback activity for old deleted users becomes assigned to unknown, you can remove this data to clean up your reports.
-			</p>
-			Keep data for
-			<select id="max_data_age_select">
-				<option value="0">Clear All</option>
-				<option value="1">1 Month</option>
-				<option value="2">2 Months</option>
-				<option value="3">3 Months</option>
-				<option value="6">6 Months</option>
-				<option value="12">1 Year</option>
-				<option value="24">2 Years</option>
-				<option value="36">3 Years</option>
-				<option value="-1">Forever</option>
-			</select>
-			<p>
-				<button id="remove_unknown_button">Remove Unknown Users</button> - Remove unknown or deleted users from the playback data.
-			</p>
+			<div class="selectContainer">
+				<label class="selectLabel" for="max_data_age_select">Keep data for</label>
+				<select is="emby-select" id="max_data_age_select" label="Data Retention" class="emby-select-withcolor emby-select">
+					<option value="0">Clear All</option>
+					<option value="1">1 Month</option>
+					<option value="2">2 Months</option>
+					<option value="3">3 Months</option>
+					<option value="6">6 Months</option>
+					<option value="12">1 Year</option>
+					<option value="24">2 Years</option>
+					<option value="36">3 Years</option>
+					<option value="-1">Forever</option>
+				</select> 
+				<div class="fieldDescription"> 
+					Keep data for X time, this is used in the scheduled task to trim your data and keep only data within the requested time period.<br />
+					As you add and remove users from your system playback activity for old deleted users becomes assigned to unknown, you can remove this data to clean up your reports.
+				</div>
+				<div class="selectArrowContainer">
+					<div style="visibility:hidden;display:none;">0</div>
+					<span class="selectArrow material-icons keyboard_arrow_down" aria-hidden="true"></span>
+				</div>
+			</div>
+
+			<div class="inputContainer">
+				<label class="selectLabel" for="remove_unknown_button">Clean unknown users</label>
+				<button is="emby-button" id="remove_unknown_button" class="raised button-delete emby-button">Remove Unknown Users</button>
+				<div class="fieldDescription">Remove unknown or deleted users from the playback data.</div> 
+			</div>
 			<br />
+
+
+
+
 			<h3>
 				<strong>Backup</strong>
 			</h3>
@@ -36,32 +49,56 @@
 				The saved backup data is in TSV format so can be loaded into other tools like Excel to build highly customised reports.
 			</p>
 			<p>
-				<button id="set_backup_path">Set Backup Path</button> - Backup Path: <span id="backup_path_label"></span><br />
+				<button is="emby-button" id="set_backup_path" class="raised button-alt headerHelpButton emby-button" style="margin-left: 0 !important;">Set Backup Path</button>  Backup Path: <span id="backup_path_label"></span><br />
 			</p>
-			<p>
-				Backup files to keep
-				<select id="files_to_keep">
+
+
+			<div class="selectContainer" style="width: 20em;">
+				<label class="selectLabel" for="files_to_keep">Backup files to keep</label>
+				<select is="emby-select" id="files_to_keep" label="Backup files to keep" class="emby-select-withcolor emby-select">
 					<option value="1">1</option>
 					<option value="5">5</option>
 					<option value="10">10</option>
 					<option value="15">15</option>
 					<option value="20">20</option>
-				</select>
-			</p>
+				</select> 
+				<div class="selectArrowContainer">
+					<div style="visibility:hidden;display:none;">0</div>
+					<span class="selectArrow material-icons keyboard_arrow_down" aria-hidden="true"></span>
+				</div>
+			</div>
+
 			<p>
-				<button id="backup_data_now">Save Backup Data</button>
-				<button id="load_backup_data">Load Backup Data</button>
+				<button id="backup_data_now" class="raised button-submit emby-button">Save Backup Data</button>
+				<button id="load_backup_data" class="raised emby-button">Load Backup Data</button>
 			</p>
 			<br />
+
+
+
 
 			<h3>
 				<strong>Ignored User List</strong>
 			</h3>
+
+			<label class="selectLabel" for="user_list_for_add" style="margin-bottom:15px;">Users can be set to ignored so you can have test users and admins that are not included in any of the reports.</label>
+			
+			<div class="selectContainer" style="width: 20em;">
+				<select is="emby-select" id="user_list_for_add" label="Data Retention" class="emby-select-withcolor emby-select">
+				</select> 
+				<div class="selectArrowContainer">
+					<div style="visibility:hidden;display:none;">0</div>
+					<span class="selectArrow material-icons keyboard_arrow_down" aria-hidden="true" style="margin: 0.2em;"></span>
+				</div>
+			</div>
+
+			<button id="add_user_to_list" class="raised button-submit emby-button">Add</button> 
+			<button id="remove_user_from_list" class="raised button-delete emby-button">Remove</button>
+
 			<p>
-				Users can be set to ignored so you can have test users and admins that are not included in any of the reports.
+				Ignored users:
 			</p>
-			<select id="user_list_for_add"></select> <button id="add_user_to_list">Add</button> <button id="remove_user_from_list">Remove</button>
-			<ul id="user_list_items"></ul>
+			<ul id="user_list_items">This list is empty.</ul>
 
 		</div>
 	</div>

--- a/Jellyfin.Plugin.PlaybackReporting/Pages/user_playback_report.html
+++ b/Jellyfin.Plugin.PlaybackReporting/Pages/user_playback_report.html
@@ -5,7 +5,7 @@
 		<div class="content-primary" style="overflow-x: scroll;">
 			<h2>User Playback Report</h2>
 
-			<style>table { display: inline-block; }</style>
+			<style>table.filter_check_list { display: inline-block; }</style>
 			<table style="padding: 1px;margin:0;" cellpadding="5" cellspacing="5" class="paperList">
 				<tr>
 					<td>
@@ -59,23 +59,24 @@
 			</table>
 
 
-			<table style="padding: 4px;margin:0;" cellpadding="5" cellspacing="5" class="paperList">
+			<table style="padding: 4px;margin:0;" cellpadding="5" cellspacing="5" class="paperList filter_check_list" >
 				<tr>
 					<td>
-						<span id="filter_check_list"></span>
+						<span id="filter_check_list" ></span>
 					</td>
 				</tr>
 			</table>
 
 			<br />
 
-			<div style="width: 100%; margin:0; padding-top: 50px">
+			<div style="width: 80%; margin:0; padding-top: 50px">
 				<canvas id="user_stats_chart_canvas"></canvas>
 			</div>
 
 			<br /><br />
 			<div>
 				User : <span id="user_report_user_name" style="font-weight: bold;">Select a user from the chart</span> <span id="user_report_on_date"></span>
+
 				<table cellpadding="6" id="user_usage_report_table" style="width:100%;">
 					<thead>
 						<tr style="text-align: left;">

--- a/Jellyfin.Plugin.PlaybackReporting/Pages/user_playback_report.html
+++ b/Jellyfin.Plugin.PlaybackReporting/Pages/user_playback_report.html
@@ -5,8 +5,7 @@
 		<div class="content-primary" style="overflow-x: scroll;">
 			<h2>User Playback Report</h2>
 
-			<style>table.filter_check_list { display: inline-block; }</style>
-			<table style="padding: 1px;margin:0;" cellpadding="5" cellspacing="5" class="paperList">
+			<table style="padding: 1px;margin:5px 0;display: inline-block;" cellpadding="5" cellspacing="5" class="paperList">
 				<tr>
 					<td>
 						End Date:
@@ -59,7 +58,7 @@
 			</table>
 
 
-			<table style="padding: 4px;margin:10px 0;" cellpadding="5" cellspacing="5" class="paperList filter_check_list" >
+			<table style="padding: 4px;margin:5px 0;display: inline-block;" cellpadding="5" cellspacing="5" class="paperList" >
 				<tr>
 					<td>
 						<span id="filter_check_list" ></span>

--- a/Jellyfin.Plugin.PlaybackReporting/Pages/user_playback_report.html
+++ b/Jellyfin.Plugin.PlaybackReporting/Pages/user_playback_report.html
@@ -5,6 +5,7 @@
 		<div class="content-primary" style="overflow-x: scroll;">
 			<h2>User Playback Report</h2>
 
+			<style>table { display: inline-block; }</style>
 			<table style="padding: 1px;margin:0;" cellpadding="5" cellspacing="5" class="paperList">
 				<tr>
 					<td>
@@ -54,11 +55,18 @@
 							</div>
 						</div>
 					</td>
+				</tr>
+			</table>
+
+
+			<table style="padding: 1px;margin:0;" cellpadding="5" cellspacing="5" class="paperList">
+				<tr>
 					<td>
 						<span id="filter_check_list"></span>
 					</td>
 				</tr>
 			</table>
+
 			<br />
 
 			<div style="width: 75%; margin:0 auto; padding-top: 100px">

--- a/Jellyfin.Plugin.PlaybackReporting/Pages/user_playback_report.html
+++ b/Jellyfin.Plugin.PlaybackReporting/Pages/user_playback_report.html
@@ -69,7 +69,7 @@
 
 			<br />
 
-			<div style="width: 75%; margin:0 auto; padding-top: 100px">
+			<div style="width: 100%; margin:0; padding-top: 50px">
 				<canvas id="user_stats_chart_canvas"></canvas>
 			</div>
 

--- a/Jellyfin.Plugin.PlaybackReporting/Pages/user_playback_report.html
+++ b/Jellyfin.Plugin.PlaybackReporting/Pages/user_playback_report.html
@@ -5,41 +5,54 @@
 		<div class="content-primary" style="overflow-x: scroll;">
 			<h2>User Playback Report</h2>
 
-			<table style="border: 1px solid black; padding: 1px;" cellpadding="5" cellspacing="5">
+			<table style="padding: 1px;margin:0;" cellpadding="5" cellspacing="5" class="paperList">
 				<tr>
 					<td>
 						End Date:
 					</td>
 					<td>
-						<input type="date" id="end_date" />
+						<input type="date" id="end_date" style="padding: .5em;" class="emby-select-withcolor emby-select"/>
 					</td>
 					<td>
 						Weeks:
 					</td>
 					<td>
-						<select id="weeks">
-							<option value="1">1</option>
-							<option value="2">2</option>
-							<option value="3">3</option>
-							<option value="4" selected>4</option>
-							<option value="5">5</option>
-							<option value="6">6</option>
-							<option value="7">7</option>
-							<option value="8">8</option>
-							<option value="9">9</option>
-							<option value="10">10</option>
-							<option value="11">11</option>
-							<option value="12">12</option>
-						</select>
+						<div class="selectContainer" style="margin:0;">
+							<select is="emby-select" id="weeks" class="emby-select-withcolor emby-select">
+								<option value="1">1</option>
+								<option value="2">2</option>
+								<option value="3">3</option>
+								<option value="4" selected>4</option>
+								<option value="5">5</option>
+								<option value="6">6</option>
+								<option value="7">7</option>
+								<option value="8">8</option>
+								<option value="9">9</option>
+								<option value="10">10</option>
+								<option value="11">11</option>
+								<option value="12">12</option>
+								<option value="-1">All</option>
+							</select>
+							<div class="selectArrowContainer">
+								<div style="visibility:hidden;display:none;">0</div>
+								<span class="selectArrow material-icons keyboard_arrow_down" aria-hidden="true" style="margin-top: 0.2em;"></span>
+							</div>
+						</div>
 					</td>
 					<td>
 						Report Type:
 					</td>
 					<td>
-						<select id="data_type">
-							<option value="count">Play Count</option>
-							<option value="time">Play Time</option>
-						</select>
+						<div class="selectContainer" style="margin:0;">
+							<select is="emby-select" id="data_type" class="emby-select-withcolor emby-select">
+								<option value="count">Play Count</option>
+								<option value="time">Play Time</option>
+							</select>
+							<div class="selectArrowContainer">
+								<div style="visibility:hidden;display:none;">0</div>
+								<span class="selectArrow material-icons keyboard_arrow_down" aria-hidden="true" style="margin-top: 0.2em;"></span>
+							</div>
+						</div>
 					</td>
 					<td>
 						<span id="filter_check_list"></span>
@@ -55,7 +68,7 @@
 			<br /><br />
 			<div>
 				User : <span id="user_report_user_name" style="font-weight: bold;">Select a user from the chart</span> <span id="user_report_on_date"></span>
-				<table cellpadding="6" id="user_usage_report_table">
+				<table cellpadding="6" id="user_usage_report_table" style="width:100%;">
 					<thead>
 						<tr style="text-align: left;">
 							<th class="detailTableHeaderCell" data-priority="2">Time</th>
@@ -67,7 +80,14 @@
 							<th class="detailTableHeaderCell" data-priority="3">Duration</th>
 						</tr>
 					</thead>
-					<tbody class="resultBody" id="user_usage_report_results"></tbody>
+					<tbody class="resultBody" id="user_usage_report_results">
+						<tr class="detailTableBodyRow detailTableBodyRow-shaded">
+							<td colspan="8" style="text-align: center;"></td>
+						</tr>
+						<tr class="detailTableBodyRow detailTableBodyRow-shaded">
+							<td colspan="8" style="text-align: center;">No data to show, please click on a user from the chart.</td>
+						</tr>
+					</tbody>
 				</table>
 			</div>
 		</div>

--- a/Jellyfin.Plugin.PlaybackReporting/Pages/user_playback_report.html
+++ b/Jellyfin.Plugin.PlaybackReporting/Pages/user_playback_report.html
@@ -59,7 +59,7 @@
 			</table>
 
 
-			<table style="padding: 4px;margin:0;" cellpadding="5" cellspacing="5" class="paperList filter_check_list" >
+			<table style="padding: 4px;margin:10px 0;" cellpadding="5" cellspacing="5" class="paperList filter_check_list" >
 				<tr>
 					<td>
 						<span id="filter_check_list" ></span>

--- a/Jellyfin.Plugin.PlaybackReporting/Pages/user_playback_report.html
+++ b/Jellyfin.Plugin.PlaybackReporting/Pages/user_playback_report.html
@@ -59,7 +59,7 @@
 			</table>
 
 
-			<table style="padding: 1px;margin:0;" cellpadding="5" cellspacing="5" class="paperList">
+			<table style="padding: 4px;margin:0;" cellpadding="5" cellspacing="5" class="paperList">
 				<tr>
 					<td>
 						<span id="filter_check_list"></span>

--- a/Jellyfin.Plugin.PlaybackReporting/Pages/user_playback_report.html
+++ b/Jellyfin.Plugin.PlaybackReporting/Pages/user_playback_report.html
@@ -69,7 +69,7 @@
 
 			<br />
 
-			<div style="width: 80%; margin:0; padding-top: 50px">
+			<div style="width: 80%; margin:0 auto; padding-top: 50px">
 				<canvas id="user_stats_chart_canvas"></canvas>
 			</div>
 

--- a/Jellyfin.Plugin.PlaybackReporting/Pages/user_playback_report.html
+++ b/Jellyfin.Plugin.PlaybackReporting/Pages/user_playback_report.html
@@ -57,7 +57,6 @@
 				</tr>
 			</table>
 
-
 			<table style="padding: 4px;margin:5px 0;display: inline-block;" cellpadding="5" cellspacing="5" class="paperList" >
 				<tr>
 					<td>

--- a/Jellyfin.Plugin.PlaybackReporting/Pages/user_playback_report.js
+++ b/Jellyfin.Plugin.PlaybackReporting/Pages/user_playback_report.js
@@ -469,7 +469,7 @@ const getConfigurationPageUrl = (name) => {
                     var filter_items = "";
                     for (var x1 = 0; x1 < filter_names.length; x1++) {
                         var filter_name_01 = filter_names[x1];
-                        filter_items += `<label class="emby-checkbox-label" style="width: 6em;line-height: 39px;">
+                        filter_items += `<label class="emby-checkbox-label" style="width: auto;line-height: 39px;padding-right: 10px;">
 							<input type="checkbox" is="emby-checkbox" id='media_type_filter_` + filter_name_01 + `' data_fileter_name='` + filter_name_01 + `' data-embycheckbox="true" checked class="emby-checkbox"> 
 							<span class="checkboxLabel">` + filter_name_01 + `</span> 
 							<span class="checkboxOutline">

--- a/Jellyfin.Plugin.PlaybackReporting/Pages/user_playback_report.js
+++ b/Jellyfin.Plugin.PlaybackReporting/Pages/user_playback_report.js
@@ -357,11 +357,11 @@ const getConfigurationPageUrl = (name) => {
 
             td = document.createElement("td");
             var btn = document.createElement("BUTTON");
-            var i = document.createElement("i");
-            i.className = "md-icon";
+            btn.className = "raised headerHelpButton emby-button";
+            btn.setAttribute('style', 'margin:0 !important');
+            btn.style.fontSize = "13px";
             var t = document.createTextNode("remove");
-            i.appendChild(t);
-            btn.appendChild(i);
+            btn.appendChild(t);
             btn.setAttribute("title", "Remove");
             btn.addEventListener("click", function () { remove_item(item_details.RowId, user_name, user_id, data_label, view); });
 

--- a/Jellyfin.Plugin.PlaybackReporting/Pages/user_playback_report.js
+++ b/Jellyfin.Plugin.PlaybackReporting/Pages/user_playback_report.js
@@ -468,8 +468,15 @@ const getConfigurationPageUrl = (name) => {
                     // build filter list
                     var filter_items = "";
                     for (var x = 0; x < filter_names.length; x++) {
-                        var filter_name = filter_names[x];
-                        filter_items += "<input type='checkbox' id='media_type_filter_" + filter_name + "' data_fileter_name='" + filter_name + "' checked> " + filter_name + " ";
+                        var filter_name_01 = filter_names[x1];
+                        filter_items += `<label class="emby-checkbox-label" style="width: 6em;line-height: 39px;">
+							<input type="checkbox" is="emby-checkbox" id='media_type_filter_` + filter_name_01 + `' data_fileter_name='` + filter_name_01 + `' data-embycheckbox="true" checked class="emby-checkbox"> 
+							<span class="checkboxLabel">` + filter_name_01 + `</span> 
+							<span class="checkboxOutline">
+								<span class="material-icons checkboxIcon checkboxIcon-checked check" aria-hidden="true"></span>
+								<span class="material-icons checkboxIcon checkboxIcon-unchecked " aria-hidden="true"></span>
+							</span>
+						</label> `;
                     }
 
                     var filter_check_list = view.querySelector('#filter_check_list');

--- a/Jellyfin.Plugin.PlaybackReporting/Pages/user_playback_report.js
+++ b/Jellyfin.Plugin.PlaybackReporting/Pages/user_playback_report.js
@@ -467,7 +467,7 @@ const getConfigurationPageUrl = (name) => {
 
                     // build filter list
                     var filter_items = "";
-                    for (var x = 0; x < filter_names.length; x++) {
+                    for (var x1 = 0; x1 < filter_names.length; x1++) {
                         var filter_name_01 = filter_names[x1];
                         filter_items += `<label class="emby-checkbox-label" style="width: 6em;line-height: 39px;">
 							<input type="checkbox" is="emby-checkbox" id='media_type_filter_` + filter_name_01 + `' data_fileter_name='` + filter_name_01 + `' data-embycheckbox="true" checked class="emby-checkbox"> 

--- a/Jellyfin.Plugin.PlaybackReporting/Pages/user_report.html
+++ b/Jellyfin.Plugin.PlaybackReporting/Pages/user_report.html
@@ -5,33 +5,39 @@
 		<div class="content-primary" style="overflow-x: scroll;">
 			<h2>User Report</h2>
 
-			<table style="border: 1px solid black; padding: 1px;" cellpadding="5" cellspacing="5">
+			<table style="padding: 1px;margin:0;" cellpadding="5" cellspacing="5" class="paperList">
 				<tr>
 					<td>
 						End Date:
 					</td>
 					<td>
-						<input type="date" id="end_date" />
+						<input type="date" id="end_date" style="padding: .5em;" class="emby-select-withcolor emby-select"/>
 					</td>
 					<td>
 						Weeks:
 					</td>
 					<td>
-						<select id="weeks">
-							<option value="1">1</option>
-							<option value="2">2</option>
-							<option value="3">3</option>
-							<option value="4" selected>4</option>
-							<option value="5">5</option>
-							<option value="6">6</option>
-							<option value="7">7</option>
-							<option value="8">8</option>
-							<option value="9">9</option>
-							<option value="10">10</option>
-							<option value="11">11</option>
-							<option value="12">12</option>
-							<option value="-1">All</option>
-						</select>
+						<div class="selectContainer" style="margin:0;">
+							<select is="emby-select" id="weeks" class="emby-select-withcolor emby-select">
+								<option value="1">1</option>
+								<option value="2">2</option>
+								<option value="3">3</option>
+								<option value="4" selected>4</option>
+								<option value="5">5</option>
+								<option value="6">6</option>
+								<option value="7">7</option>
+								<option value="8">8</option>
+								<option value="9">9</option>
+								<option value="10">10</option>
+								<option value="11">11</option>
+								<option value="12">12</option>
+								<option value="-1">All</option>
+							</select>
+							<div class="selectArrowContainer">
+								<div style="visibility:hidden;display:none;">0</div>
+								<span class="selectArrow material-icons keyboard_arrow_down" aria-hidden="true" style="margin-top: 0.2em;"></span>
+							</div>
+						</div>
 					</td>
 				</tr>
 			</table>
@@ -39,7 +45,7 @@
 			<br />
 			<br />
 
-			<table cellpadding="6" id="user_usage_report_table" style="width:95%;">
+			<table cellpadding="6" id="user_usage_report_table" style="width:100%;">
 				<thead>
 					<tr style="text-align: left;">
 						<th class="detailTableHeaderCell" data-priority="2">&nbsp;</th>


### PR DESCRIPTION
This PR is a redesign, or well, add design to this plugin, by adding Jellyfin CSS classes and HTML where needed. I used the main Jellyfin settings as a base to get all the right design where needed.

Click on the image:

# Desktop Preview

| Page | Before | After |
|--------|--------|--------|
| User Report | ![image](https://github.com/user-attachments/assets/806cda75-9674-44e2-bbd9-d46d9d6964c9) | ![image](https://github.com/user-attachments/assets/d03f17bd-bd52-42e2-a1d2-87394283b1f9) |
| User Playback Report | ![image](https://github.com/user-attachments/assets/37dbf8de-40e2-4fc7-9ab4-51eea082012b)  | ![image](https://github.com/user-attachments/assets/1b8d1181-75ee-420e-9065-f067e1740fbd) |
| Breakdown Report | ![image](https://github.com/user-attachments/assets/de7b15ae-3111-42bb-ba3a-91b9415ae9bd)  | ![image](https://github.com/user-attachments/assets/9f896bea-3b1c-4606-97c3-507d28660f72) |
| Usage Report | ![image](https://github.com/user-attachments/assets/aef48e1a-d4af-4313-b0ea-476fcc4fdc11)  | ![image](https://github.com/user-attachments/assets/fddab460-f7e3-4f61-97ca-21f961acb2bd) |
| Playback Session Duration Report | ![image](https://github.com/user-attachments/assets/ba806027-0d68-4553-a804-a6b51af67f1f)  | ![image](https://github.com/user-attachments/assets/61b0a11a-9477-404d-a887-4b23530e382f) | 
| Custom Query Report | ![image](https://github.com/user-attachments/assets/99ab34ea-73ee-4a20-aa81-759a070a2488) | ![image](https://github.com/user-attachments/assets/9789cffd-c2cc-4a4e-83e0-965789133b36) | 
| Playback Report Settings | ![image](https://github.com/user-attachments/assets/78e4c668-5058-47be-9e5f-301f33164c9e) | ![image](https://github.com/user-attachments/assets/7f495eb5-124c-4b99-a3d3-b42cc4b670f9) | 


# Mobile Preview

| Page | Before | After |
|--------|--------|--------|
| User Playback Report | ![image](https://github.com/user-attachments/assets/40ee7c1c-4347-4761-91f6-13cf6e313eec) | ![image](https://github.com/user-attachments/assets/de44176b-4d18-41c0-9f65-8276f2ed97c8) |


# Other previews

| Page | After |
|--------|--------|
| User Playback Reporting no data | ![image](https://github.com/user-attachments/assets/6ef07e9b-b1df-4c68-bfe0-3f7fd86317c6) | 
| User Playback Reporting with data | ![image](https://github.com/user-attachments/assets/0b52b122-d240-4918-bff6-8e62541b53e0)  |


I did not touch graphs or any code related to data handling, this is all just cosmetic.

Note to myself: revert change of the file Jellyfin.Plugin.PlaybackReporting.csproj before merging, this change was temporary to be able to build for my Jellyfin version using github actions