### PR TITLE
add own configuration endpoint

### DIFF
--- a/Jellyfin.Plugin.PlaybackReporting/Api/PlaybackReportingConfigurationController.cs
+++ b/Jellyfin.Plugin.PlaybackReporting/Api/PlaybackReportingConfigurationController.cs
@@ -1,0 +1,74 @@
+/*
+Copyright(C) 2018
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see<http://www.gnu.org/licenses/>.
+*/
+
+using System.ComponentModel.DataAnnotations;
+using System.Net.Mime;
+using MediaBrowser.Common.Api;
+using MediaBrowser.Controller.Configuration;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Jellyfin.Plugin.PlaybackReporting.Api
+{
+    /// <summary>
+    /// Playback Reporting Configuration Controller.
+    /// </summary>
+    [ApiController]
+    [Route("System")]
+    [Authorize]
+    [Produces(MediaTypeNames.Application.Json)]
+    public class PlaybackReportingConfigurationController : ControllerBase
+    {
+        private readonly IServerConfigurationManager _configurationManager;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PlaybackReportingConfigurationController"/> class.
+        /// </summary>
+        /// <param name="configurationManager">Instance of the <see cref="IServerConfigurationManager"/> interface.</param>
+        public PlaybackReportingConfigurationController(IServerConfigurationManager configurationManager)
+        {
+            _configurationManager = configurationManager;
+        }
+
+        /// <summary>
+        /// Gets playback reporting configuration.
+        /// </summary>
+        /// <response code="200">Playback reporting configuration returned.</response>
+        /// <returns>Playback reporting configuration.</returns>
+        [HttpGet("Configuration/playback_reporting")]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        public ActionResult<ReportPlaybackOptions> GetPlaybackReportingConfiguration()
+        {
+            return _configurationManager.GetReportPlaybackOptions();
+        }
+
+        /// <summary>
+        /// Updates playback reporting configuration.
+        /// </summary>
+        /// <param name="configuration">Configuration.</param>
+        /// <response code="204">Configuration updated.</response>
+        /// <returns>Update status.</returns>
+        [HttpPost("Configuration/playback_reporting")]
+        [Authorize(Policy = Policies.RequiresElevation)]
+        [ProducesResponseType(StatusCodes.Status204NoContent)]
+        public ActionResult UpdatePlaybackReportingConfiguration([FromBody, Required] ReportPlaybackOptions configuration)
+        {
+            _configurationManager.SaveReportPlaybackOptions(configuration);
+            return NoContent();
+        }
+    }
+}

--- a/Jellyfin.Plugin.PlaybackReporting/Pages/playback_report_settings.js
+++ b/Jellyfin.Plugin.PlaybackReporting/Pages/playback_report_settings.js
@@ -27,11 +27,28 @@ const getConfigurationPageUrl = (name) => {
         });
     };
 
+    window.ApiClient.getPlaybackReportingConfiguration = function () {
+        return this.ajax({
+            type: "GET",
+            url: this.getUrl("System/Configuration/playback_reporting"),
+            dataType: "json"
+        });
+    };
+
+    window.ApiClient.updatePlaybackReportingConfiguration = function (config) {
+        return this.ajax({
+            type: "POST",
+            url: this.getUrl("System/Configuration/playback_reporting"),
+            data: JSON.stringify(config),
+            contentType: "application/json"
+        });
+    };
+
     function setBackupPathCallBack(selectedDir, view) {
-        window.ApiClient.getNamedConfiguration('playback_reporting').then(function (config) {
+        window.ApiClient.getPlaybackReportingConfiguration().then(function (config) {
             config.BackupPath = selectedDir;
             console.log("New Config Settings : " + JSON.stringify(config));
-            window.ApiClient.updateNamedConfiguration('playback_reporting', config);
+            window.ApiClient.updatePlaybackReportingConfiguration(config);
 
             var backup_path_label = view.querySelector('#backup_path_label');
             backup_path_label.innerHTML = selectedDir;
@@ -92,7 +109,7 @@ const getConfigurationPageUrl = (name) => {
             //alert("Loaded Data: " + JSON.stringify(usage_data));
             alert(responce_message[0]);
 
-            window.ApiClient.getNamedConfiguration('playback_reporting').then(function (config) {
+            window.ApiClient.getPlaybackReportingConfiguration().then(function (config) {
                 var backup_path_label = view.querySelector('#backup_path_label');
                 backup_path_label.innerHTML = config.BackupPath;
             });
@@ -166,19 +183,19 @@ const getConfigurationPageUrl = (name) => {
 
             function files_to_keep_changed() {
                 var max_files = backup_files_to_keep.value;
-                window.ApiClient.getNamedConfiguration('playback_reporting').then(function (config) {
+                window.ApiClient.getPlaybackReportingConfiguration().then(function (config) {
                     config.MaxBackupFiles = max_files;
                     console.log("New Config Settings : " + JSON.stringify(config));
-                    window.ApiClient.updateNamedConfiguration('playback_reporting', config);
+                    window.ApiClient.updatePlaybackReportingConfiguration(config);
                 });
             }
 
             function setting_changed() {
                 var max_age = max_data_age_select.value;
-                window.ApiClient.getNamedConfiguration('playback_reporting').then(function (config) {
+                window.ApiClient.getPlaybackReportingConfiguration().then(function (config) {
                     config.MaxDataAge = max_age;
                     console.log("New Config Settings : " + JSON.stringify(config));
-                    window.ApiClient.updateNamedConfiguration('playback_reporting', config);
+                    window.ApiClient.updatePlaybackReportingConfiguration(config);
                 });
             }
 
@@ -217,7 +234,7 @@ const getConfigurationPageUrl = (name) => {
 
             });
 
-            window.ApiClient.getNamedConfiguration('playback_reporting').then(function (config) {
+            window.ApiClient.getPlaybackReportingConfiguration().then(function (config) {
                 loadPage(view, config);
             });
 


### PR DESCRIPTION
This is necessary when [#16682](https://github.com/jellyfin/jellyfin/pull/16682) gets merged.

Previously this was handled by generic configuration endpoint.