### PR TITLE
Fix _userManager.Users -> GetUsers() for Jellyfin 10.11.9

### DIFF
--- a/Jellyfin.Plugin.PlaybackReporting/Api/PlaybackReportingActivityController.cs
+++ b/Jellyfin.Plugin.PlaybackReporting/Api/PlaybackReportingActivityController.cs
@@ -133,7 +133,7 @@ namespace Jellyfin.Plugin.PlaybackReporting.Api
         public ActionResult<bool> PruneUnknownUsers()
         {
             List<string> userIdList = new List<string>();
-            foreach (var jellyfinUser in _userManager.Users)
+            foreach (var jellyfinUser in _userManager.GetUsers())
             {
                 userIdList.Add(jellyfinUser.Id.ToString("N"));
             }
@@ -182,7 +182,7 @@ namespace Jellyfin.Plugin.PlaybackReporting.Api
 
             List<Dictionary<string, object>> users = new List<Dictionary<string, object>>();
 
-            foreach (var jellyfinUser in _userManager.Users)
+            foreach (var jellyfinUser in _userManager.GetUsers())
             {
                 Dictionary<string, object> user_info = new Dictionary<string, object>
                 {
@@ -541,7 +541,7 @@ namespace Jellyfin.Plugin.PlaybackReporting.Api
                 colums[index_of_user_col] = "UserName";
 
                 Dictionary<string, string> user_map = new Dictionary<string, string>();
-                foreach (var user in _userManager.Users)
+                foreach (var user in _userManager.GetUsers())
                 {
                     user_map.Add(user.Id.ToString("N"), user.Username);
                 }


### PR DESCRIPTION
Replace removed `IUserManager.Users` property with `GetUsers()` so the plugin builds against Jellyfin 10.11.9.

Jellyfin 10.11.9 backported the `IUserManager.Users` → `GetUsers()` API change from 12.x (see [jellyfin/jellyfin@2ac0edc](https://github.com/jellyfin/jellyfin/commit/2ac0edc052ed5d22cee3d46fb933bb12a2b36283)), so the current master branch no longer compiles against stable.

Mirrors the equivalent change made on `unstable` in commit 6b6a89f.

Build errors before this change:
```
Api/PlaybackReportingActivityController.cs(136,55): error CS1061: 'IUserManager' does not contain a definition for 'Users'
Api/PlaybackReportingActivityController.cs(185,55): error CS1061: 'IUserManager' does not contain a definition for 'Users'
Api/PlaybackReportingActivityController.cs(544,51): error CS1061: 'IUserManager' does not contain a definition for 'Users'
```