### PR TITLE
Store UTC datetimes to fix timezone related issues

### DIFF
--- a/Jellyfin.Plugin.PlaybackReporting/Api/PlaybackReportingActivityController.cs
+++ b/Jellyfin.Plugin.PlaybackReporting/Api/PlaybackReportingActivityController.cs
@@ -60,7 +60,7 @@ namespace Jellyfin.Plugin.PlaybackReporting.Api
 
             _logger.LogInformation("PlaybackReportingActivityController Loaded");
             var repo = new ActivityRepository(loggerFactory.CreateLogger<ActivityRepository>(), _config.ApplicationPaths, _fileSystem);
-            //repo.Initialize();
+            repo.Initialize();
             _repository = repo;
         }
 
@@ -79,14 +79,15 @@ namespace Jellyfin.Plugin.PlaybackReporting.Api
         /// Gets a report of the available activity per hour.
         /// </summary>
         /// <param name="days">Number of Days</param>
-        /// <param name="endDate">Optional. End date of the report in yyyy-MM-dd format. Defaults to <see cref="DateTime.Now"/>.</param>
+        /// <param name="endDate">Optional. End date of the report in yyyy-MM-dd format. Defaults to today's date in the client's timezone.</param>
+        /// <param name="timezoneId">Optional. The timezone id to use in datetime calculations. Defaults to UTC</param>
         /// <response code="200">Report returned.</response>
         /// <returns></returns>
         [HttpGet("user_activity")]
         [ProducesResponseType(StatusCodes.Status200OK)]
-        public ActionResult GetUserReport([FromQuery] int days, [FromQuery] DateTime? endDate, [FromQuery] float? timezoneOffset)
+        public ActionResult GetUserReport([FromQuery] int days, [FromQuery] DateTime? endDate, [FromQuery] string? timezoneId)
         {
-            List<Dictionary<string, object>> report = _repository.GetUserReport(days, endDate ?? DateTime.Now, timezoneOffset ?? 0);
+            List<Dictionary<string, object>> report = _repository.GetUserReport(days, ResolveDate(endDate, timezoneId), timezoneId ?? "UTC");
 
             foreach(var user_info in report)
             {
@@ -100,7 +101,7 @@ namespace Jellyfin.Plugin.PlaybackReporting.Api
                 user_info.Add("has_image", has_image);
 
                 DateTime last_seen = (DateTime)user_info["latest_date"];
-                TimeSpan time_ago = DateTime.Now.Subtract(last_seen);
+                TimeSpan time_ago = DateTime.UtcNow.Subtract(last_seen);
 
                 string last_seen_string = GetLastSeenString(time_ago);
                 if (last_seen_string == "")
@@ -202,11 +203,12 @@ namespace Jellyfin.Plugin.PlaybackReporting.Api
         /// <param name="userId">User Id.</param>
         /// <param name="date">UTC DateTime, Format yyyy-MM-dd.</param>
         /// <param name="filter">Comma separated list of media types to filter (movies,series).</param>
+        /// <param name="timezoneId">Optional. The timezone id to use in datetime calculations. Defaults to UTC</param>
         /// <response code="200">Activity returned.</response>
         /// <returns></returns>
         [HttpGet("{userId}/{date}/GetItems")]
         [ProducesResponseType(StatusCodes.Status200OK)]
-        public ActionResult GetUserReportData([FromRoute] string userId, [FromRoute] string date, [FromQuery] string? filter, [FromQuery] float? timezoneOffset)
+        public ActionResult GetUserReportData([FromRoute] string userId, [FromRoute] string date, [FromQuery] string? filter, [FromQuery] string? timezoneId)
         {
             string[] filter_tokens = Array.Empty<string>();
             if (filter != null)
@@ -214,7 +216,7 @@ namespace Jellyfin.Plugin.PlaybackReporting.Api
                 filter_tokens = filter.Split(',');
             }
 
-            List<Dictionary<string, string>> results = _repository.GetUsageForUser(date, userId, filter_tokens, timezoneOffset ?? 0);
+            List<Dictionary<string, string>> results = _repository.GetUsageForUser(date, userId, filter_tokens, timezoneId ?? "UTC");
 
             List<Dictionary<string, object>> user_activity = new List<Dictionary<string, object>>();
 
@@ -296,11 +298,12 @@ namespace Jellyfin.Plugin.PlaybackReporting.Api
         /// <param name="endDate">End date of the report in yyyy-MM-dd format.</param>
         /// <param name="filter">Comma separated list of media types to filter (movies,series).</param>
         /// <param name="dataType">Data type to return (count,time).</param>
+        /// <param name="timezoneId">Optional. The timezone id to use in datetime calculations. Defaults to UTC</param>
         /// <response code="200">Activity returned.</response>
         /// <returns></returns>
         [HttpGet("PlayActivity")]
         [ProducesResponseType(StatusCodes.Status200OK)]
-        public ActionResult GetUsageStats(int days, DateTime? endDate, string? filter, string? dataType, [FromQuery] float? timezoneOffset)
+        public ActionResult GetUsageStats(int days, DateTime? endDate, string? filter, string? dataType, [FromQuery] string? timezoneId)
         {
             string[] filter_tokens = Array.Empty<string>();
             if (filter != null)
@@ -308,9 +311,9 @@ namespace Jellyfin.Plugin.PlaybackReporting.Api
                 filter_tokens = filter.Split(',');
             }
 
-            endDate ??= DateTime.Now;
+            DateTime resolvedEndDate = ResolveDate(endDate, timezoneId);
 
-            Dictionary<String, Dictionary<string, int>> results = _repository.GetUsageForDays(days, endDate.Value, filter_tokens, dataType, timezoneOffset ?? 0);
+            Dictionary<String, Dictionary<string, int>> results = _repository.GetUsageForDays(days, resolvedEndDate, filter_tokens, dataType, timezoneId ?? "UTC");
 
             // add empty user for labels
             results.Add("labels_user", new Dictionary<string, int>());
@@ -322,8 +325,8 @@ namespace Jellyfin.Plugin.PlaybackReporting.Api
 
                 // fill in missing dates for time period
                 SortedDictionary<string, int> userUsageByDate = new SortedDictionary<string, int>();
-                DateTime from_date = endDate.Value.AddDays(days * -1 + 1);
-                while (from_date <= endDate.Value)
+                DateTime from_date = resolvedEndDate.AddDays(days * -1 + 1);
+                while (from_date <= resolvedEndDate)
                 {
                     string date_string = from_date.ToString("yyyy-MM-dd");
                     if (user_usage.ContainsKey(date_string) == false)
@@ -374,10 +377,11 @@ namespace Jellyfin.Plugin.PlaybackReporting.Api
         /// <param name="days">Number of Days.</param>
         /// <param name="endDate">End date of the report in yyyy-MM-dd format.</param>
         /// <param name="filter">Comma separated list of media types to filter (movies,series).</param>
+        /// <param name="timezoneId">Optional. The timezone id to use in datetime calculations. Defaults to UTC</param>
         /// <returns></returns>
         [HttpGet("HourlyReport")]
         [ProducesResponseType(StatusCodes.Status200OK)]
-        public ActionResult GetHourlyReport(int days, DateTime? endDate, string? filter, [FromQuery] float? timezoneOffset)
+        public ActionResult GetHourlyReport(int days, DateTime? endDate, string? filter, [FromQuery] string? timezoneId)
         {
             string[] filter_tokens = Array.Empty<string>();
             if (filter != null)
@@ -385,9 +389,7 @@ namespace Jellyfin.Plugin.PlaybackReporting.Api
                 filter_tokens = filter.Split(',');
             }
 
-            endDate ??= DateTime.Now;
-
-            SortedDictionary<string, int> report = _repository.GetHourlyUsageReport(days, endDate.Value, filter_tokens, timezoneOffset ?? 0);
+            SortedDictionary<string, int> report = _repository.GetHourlyUsageReport(days, ResolveDate(endDate, timezoneId), filter_tokens, timezoneId ?? "UTC");
 
             for (int day = 0; day < 7; day++)
             {
@@ -410,13 +412,14 @@ namespace Jellyfin.Plugin.PlaybackReporting.Api
         /// <param name="breakdownType"></param>
         /// <param name="days">Number of days.</param>
         /// <param name="endDate">End date of the report in yyyy-MM-dd format.</param>
+        /// <param name="timezoneId">Optional. The timezone id to use in datetime calculations. Defaults to UTC</param>
         /// <response code="200">Activity returned.</response>
         /// <returns></returns>
         [HttpGet("{breakdownType}/BreakdownReport")]
         [ProducesResponseType(StatusCodes.Status200OK)]
-        public ActionResult GetBreakdownReport([FromRoute] string breakdownType, int days, DateTime? endDate, [FromQuery] float? timezoneOffset)
+        public ActionResult GetBreakdownReport([FromRoute] string breakdownType, int days, DateTime? endDate, [FromQuery] string? timezoneId)
         {
-            List<Dictionary<string, object>> report = _repository.GetBreakdownReport(days, endDate ?? DateTime.Now, breakdownType, timezoneOffset ?? 0);
+            List<Dictionary<string, object>> report = _repository.GetBreakdownReport(days, ResolveDate(endDate, timezoneId), breakdownType, timezoneId ?? "UTC");
 
             if (breakdownType == "UserId")
             {
@@ -448,11 +451,12 @@ namespace Jellyfin.Plugin.PlaybackReporting.Api
         /// <param name="days">Number of Days.</param>
         /// <param name="endDate">End date of the report in yyyy-MM-dd format.</param>
         /// <param name="filter">Comma separated list of media types to filter (movies,series).</param>
+        /// <param name="timezoneId">Optional. The timezone id to use in datetime calculations. Defaults to UTC</param>
         /// <response code="200">Histogram returned.</response>
         /// <returns></returns>
         [HttpGet("DurationHistogramReport")]
         [ProducesResponseType(StatusCodes.Status200OK)]
-        public ActionResult GetDurationHistogramReport(int days, DateTime? endDate, string? filter)
+        public ActionResult GetDurationHistogramReport(int days, DateTime? endDate, string? filter, [FromQuery] string? timezoneId)
         {
             string[] filter_tokens = Array.Empty<string>();
             if (filter != null)
@@ -460,7 +464,7 @@ namespace Jellyfin.Plugin.PlaybackReporting.Api
                 filter_tokens = filter.Split(',');
             }
 
-            SortedDictionary<int, int> report = _repository.GetDurationHistogram(days, endDate ?? DateTime.Now, filter_tokens);
+            SortedDictionary<int, int> report = _repository.GetDurationHistogram(days, ResolveDate(endDate, timezoneId), filter_tokens, timezoneId ?? "UTC");
 
             // find max
             int max = -1;
@@ -488,12 +492,13 @@ namespace Jellyfin.Plugin.PlaybackReporting.Api
         /// </summary>
         /// <param name="days">Number of Days.</param>
         /// <param name="endDate">End date of the report in yyyy-MM-dd format.</param>
+        /// <param name="timezoneId">Optional. The timezone id to use in datetime calculations. Defaults to UTC</param>
         /// <returns></returns>
         [HttpGet("GetTvShowsReport")]
         [ProducesResponseType(StatusCodes.Status200OK)]
-        public ActionResult GetTvShowsReport(int days, DateTime? endDate, [FromQuery] float? timezoneOffset)
+        public ActionResult GetTvShowsReport(int days, DateTime? endDate, [FromQuery] string? timezoneId)
         {
-            return Ok(_repository.GetTvShowReport(days, endDate ?? DateTime.Now, timezoneOffset ?? 0));
+            return Ok(_repository.GetTvShowReport(days, ResolveDate(endDate, timezoneId), timezoneId ?? "UTC"));
         }
 
         /// <summary>
@@ -501,13 +506,14 @@ namespace Jellyfin.Plugin.PlaybackReporting.Api
         /// </summary>
         /// <param name="days">Number of Days.</param>
         /// <param name="endDate">End date of the report in yyyy-MM-dd format.</param>
+        /// <param name="timezoneId">Optional. The timezone id to use in datetime calculations. Defaults to UTC</param>
         /// <response code="200">TV Shows returned.</response>
         /// <returns></returns>
         [HttpGet("MoviesReport")]
         [ProducesResponseType(StatusCodes.Status200OK)]
-        public ActionResult GetMovieReport(int days, DateTime? endDate, [FromQuery] float? timezoneOffset)
+        public ActionResult GetMovieReport(int days, DateTime? endDate, [FromQuery] string? timezoneId)
         {
-            return Ok(_repository.GetMoviesReport(days, endDate ?? DateTime.Now, timezoneOffset ?? 0));
+            return Ok(_repository.GetMoviesReport(days, ResolveDate(endDate, timezoneId), timezoneId ?? "UTC"));
         }
 
         public class CustomQueryData
@@ -603,6 +609,17 @@ namespace Jellyfin.Plugin.PlaybackReporting.Api
                 part += "s";
             }
             return part + " ";
+        }
+
+        private DateTime ResolveDate(DateTime? date, string? timezoneId)
+        {
+            if (date.HasValue)
+            {
+                return DateTime.SpecifyKind(date.Value, DateTimeKind.Unspecified);
+            }
+
+            var timezone = TimeZoneHelper.Resolve(timezoneId ?? "UTC", _logger);
+            return TimeZoneInfo.ConvertTimeFromUtc(DateTime.UtcNow, timezone).Date;
         }
     }
 }

--- a/Jellyfin.Plugin.PlaybackReporting/BackupManager.cs
+++ b/Jellyfin.Plugin.PlaybackReporting/BackupManager.cs
@@ -39,6 +39,7 @@ namespace Jellyfin.Plugin.PlaybackReporting
             _logger = loggerFactory.CreateLogger<BackupManager>();
 
             _repository = new ActivityRepository(loggerFactory.CreateLogger<ActivityRepository>(), _config.ApplicationPaths, _fileSystem);
+            _repository.Initialize();
         }
 
 

--- a/Jellyfin.Plugin.PlaybackReporting/Data/ActivityRepository.cs
+++ b/Jellyfin.Plugin.PlaybackReporting/Data/ActivityRepository.cs
@@ -26,7 +26,6 @@ namespace Jellyfin.Plugin.PlaybackReporting.Data
 {
     public class ActivityRepository : BaseSqliteRepository, IActivityRepository
     {
-        private static readonly string DATE_TIME_FORMAT = "yyyy-MM-dd HH:mm:ss";
         private readonly ILogger<ActivityRepository> _logger;
         protected IFileSystem FileSystem { get; private set; }
 
@@ -47,8 +46,7 @@ namespace Jellyfin.Plugin.PlaybackReporting.Data
             catch (Exception ex)
             {
                 Logger.LogError(ex, "Error loading PlaybackActivity database file.");
-                //FileSystem.DeleteFile(DbFilePath);
-                //InitializeInternal();
+                throw;
             }
         }
 
@@ -97,13 +95,46 @@ namespace Jellyfin.Plugin.PlaybackReporting.Data
                                 ")");
 
                 connection.Execute("create table if not exists UserList (UserId TEXT)");
+
+                MigrateDateCreatedToUtc(connection);
             }
         }
 
-        private TimeSpan CalculateUserServerTimezoneOffset(float userOffset)
+        private void MigrateDateCreatedToUtc(ManagedConnection connection)
         {
-            var serverOffset = TimeZoneInfo.Local.GetUtcOffset(DateTime.UtcNow);
-            return serverOffset.Subtract(TimeSpan.FromHours(userOffset));
+            int version = 0;
+            foreach (var row in connection.Query("PRAGMA user_version"))
+            {
+                version = row[0].ToInt();
+                break;
+            }
+
+            if (version >= 1)
+            {
+                _logger.LogInformation("PlaybackActivity DateCreated already in UTC (user_version = {Version})", version);
+                return;
+            }
+
+            TimeZoneInfo legacyTimezone = TimeZoneInfo.Local;
+            int migrated = 0;
+            connection.RunInTransaction(db =>
+            {
+                using var select = db.PrepareStatement("SELECT rowid, DateCreated FROM PlaybackActivity");
+                using var update = db.PrepareStatement("UPDATE PlaybackActivity SET DateCreated = @DateCreated WHERE rowid = @rowid");
+                foreach (var row in select.ExecuteQuery())
+                {
+                    string utcDate = row[1].ToString().ParseDateTimeToUtc(legacyTimezone).ToUtcDateParamValue();
+                    update.Execute(utcDate, row[0].ToInt());
+                    migrated++;
+                }
+
+                db.Execute("PRAGMA user_version = 1");
+            }, TransactionMode);
+
+            if (migrated > 0)
+            {
+                _logger.LogInformation("Migrated {Count} PlaybackActivity rows to UTC using the server timezone ({ServerTimezoneId}).", migrated, legacyTimezone.Id);
+            }
         }
 
         public string RunCustomQuery(string query_string, List<string> col_names, List<List<object>> results)
@@ -234,6 +265,8 @@ namespace Jellyfin.Plugin.PlaybackReporting.Data
         public int ImportRawData(string data)
         {
             int count = 0;
+            int skipped_lines = 0;
+            TimeZoneInfo legacyTimezone = TimeZoneInfo.Local;
             _logger.LogInformation("Loading Data");
             using (WriteLock.Write())
             {
@@ -247,11 +280,23 @@ namespace Jellyfin.Plugin.PlaybackReporting.Data
                     _logger.LogInformation("Line Length : {NumberOfTokens}", tokens.Length);
                     if (tokens.Length != 9)
                     {
+                        skipped_lines++;
                         line = sr!.ReadLine();
                         continue;
                     }
 
-                    string date = tokens[0];
+                    string date;
+                    try
+                    {
+                        date = tokens[0].ParseDateTimeToUtc(legacyTimezone).ToUtcDateParamValue();
+                    }
+                    catch (FormatException)
+                    {
+                        skipped_lines++;
+                        _logger.LogWarning("Skipping import line with unparsable date '{DateToken}'", tokens[0]);
+                        line = sr!.ReadLine();
+                        continue;
+                    }
                     string user_id = tokens[1];
                     string item_id = tokens[2];
                     string item_type = tokens[3];
@@ -307,6 +352,10 @@ namespace Jellyfin.Plugin.PlaybackReporting.Data
                     line = sr?.ReadLine();
                 }
             }
+            if (skipped_lines > 0)
+            {
+                _logger.LogWarning("Import skipped {SkippedLines} line(s) with invalid format", skipped_lines);
+            }
             return count;
         }
 
@@ -339,7 +388,7 @@ namespace Jellyfin.Plugin.PlaybackReporting.Data
             if (delBefore != null)
             {
                 DateTime date = (DateTime)delBefore;
-                sql += " where DateCreated < '" + date.ToDateTimeParamValue() + "'";
+                sql += " where DateCreated < '" + date.ToUtcDateParamValue() + "'";
             }
 
             _logger.LogInformation("DeleteOldData : {Sql}", sql);
@@ -367,7 +416,7 @@ namespace Jellyfin.Plugin.PlaybackReporting.Data
                 connection.RunInTransaction(db =>
                 {
                     using var statement = db.PrepareStatement(sql_add);
-                    statement.TryBind("@DateCreated", playInfo.Date.ToDateTimeParamValue());
+                    statement.TryBind("@DateCreated", playInfo.Date.ToUtcDateParamValue());
                     statement.TryBind("@UserId", playInfo.UserId);
                     statement.TryBind("@ItemId", playInfo.ItemId);
                     statement.TryBind("@ItemType", playInfo.ItemType);
@@ -390,7 +439,7 @@ namespace Jellyfin.Plugin.PlaybackReporting.Data
                 connection.RunInTransaction(db =>
                 {
                     using var statement = db.PrepareStatement(sql_add);
-                    statement.TryBind("@DateCreated", playInfo.Date.ToDateTimeParamValue());
+                    statement.TryBind("@DateCreated", playInfo.Date.ToUtcDateParamValue());
                     statement.TryBind("@UserId", playInfo.UserId);
                     statement.TryBind("@ItemId", playInfo.ItemId);
                     statement.TryBind("@PlayDuration", playInfo.PlaybackDuration);
@@ -399,7 +448,7 @@ namespace Jellyfin.Plugin.PlaybackReporting.Data
             }
         }
 
-        public List<Dictionary<string, string>> GetUsageForUser(string date, string userId, string[] types, float timezoneOffset)
+        public List<Dictionary<string, string>> GetUsageForUser(string date, string userId, string[] types, string timezoneId)
         {
             List<string> filters = new List<string>();
             foreach (string filter in types)
@@ -409,7 +458,7 @@ namespace Jellyfin.Plugin.PlaybackReporting.Data
 
             string sql_query = "SELECT DateCreated, ItemId, ItemType, ItemName, ClientName, PlaybackMethod, DeviceName, PlayDuration, rowid " +
                                "FROM PlaybackActivity " +
-                               "WHERE DateCreated >= @date_from AND DateCreated <= @date_to " +
+                                "WHERE DateCreated >= @date_from AND DateCreated < @date_to " +
                                "AND UserId = @user_id " +
                                "AND ItemType IN (" + string.Join(",", filters) + ") " +
                                "ORDER BY DateCreated";
@@ -419,18 +468,20 @@ namespace Jellyfin.Plugin.PlaybackReporting.Data
             {
                 using var connection = CreateConnection(true);
                 using var statement = connection.PrepareStatement(sql_query);
-                var userServerTimezoneOffset = CalculateUserServerTimezoneOffset(timezoneOffset);
-                var fromDate = DateTime.Parse(date + " 00:00:00").Add(userServerTimezoneOffset);
-                var toDate = fromDate.AddHours(23).AddMinutes(59).AddSeconds(59);
-                statement.TryBind("@date_from", fromDate.ToString(DATE_TIME_FORMAT));
-                statement.TryBind("@date_to", toDate.ToString(DATE_TIME_FORMAT));
+                var userTimezone = TimeZoneHelper.Resolve(timezoneId, _logger);
+                var localDate = DateTime.Parse(date).Date;
+                var range = new TimeZoneHelper.DateRange(
+                    TimeZoneHelper.UserLocalToUtc(localDate, userTimezone),
+                    TimeZoneHelper.UserLocalToUtc(localDate.AddDays(1), userTimezone));
+                statement.TryBind("@date_from", range.StartUtc.ToDateTimeParamValue());
+                statement.TryBind("@date_to", range.EndUtc.ToDateTimeParamValue());
                 statement.TryBind("@user_id", userId);
                 foreach (var row in statement.ExecuteQuery())
                 {
                     var time = row[0].ReadDateTime();
                     Dictionary<string, string> item = new Dictionary<string, string>
                     {
-                        ["Time"] = time.Add(userServerTimezoneOffset).ToString("h:mm tt"),
+                        ["Time"] = TimeZoneHelper.UtcToUserLocal(time, userTimezone).ToString("h:mm tt"),
                         ["Id"] = row[1].ToString(),
                         ["Type"] = row[2].ToString(),
                         ["ItemName"] = row[3].ToString(),
@@ -448,7 +499,7 @@ namespace Jellyfin.Plugin.PlaybackReporting.Data
             return items;
         }
 
-        public Dictionary<String, Dictionary<string, int>> GetUsageForDays(int days, DateTime endDate, string[] types, string? dataType, float timezoneOffset)
+        public Dictionary<String, Dictionary<string, int>> GetUsageForDays(int days, DateTime endDate, string[] types, string? dataType, string timezoneId)
         {
             List<string> filters = new List<string>();
             foreach (string filter in types)
@@ -466,14 +517,13 @@ namespace Jellyfin.Plugin.PlaybackReporting.Data
                 sql_query += "SELECT UserId, DateCreated AS date, SUM(PlayDuration) AS count ";
             }
             sql_query += "FROM PlaybackActivity ";
-            sql_query += "WHERE DateCreated >= @start_date AND DateCreated <= @end_date ";
+            sql_query += "WHERE DateCreated >= @start_date AND DateCreated < @end_date ";
             sql_query += "AND ItemType IN (" + string.Join(",", filters) + ") ";
             sql_query += "AND UserId not IN (select UserId from UserList) ";
             sql_query += "GROUP BY UserId, date ORDER BY UserId, date ASC";
 
-            var userServerTimezoneOffset = CalculateUserServerTimezoneOffset(timezoneOffset);
-            endDate = endDate.Add(userServerTimezoneOffset);
-            DateTime start_date = endDate.Subtract(new TimeSpan(days, 0, 0, 0));
+            var userTimezone = TimeZoneHelper.Resolve(timezoneId, _logger);
+            var range = TimeZoneHelper.GetDateRange(days, endDate, userTimezone);
 
             Dictionary<string, Dictionary<string, int>> usage = new Dictionary<string, Dictionary<string, int>>();
 
@@ -481,8 +531,8 @@ namespace Jellyfin.Plugin.PlaybackReporting.Data
             {
                 using var connection = CreateConnection(true);
                 using var statement = connection.PrepareStatement(sql_query);
-                statement.TryBind("@start_date", start_date.ToString(DATE_TIME_FORMAT));
-                statement.TryBind("@end_date", endDate.AddDays(1).AddSeconds(-1).ToString(DATE_TIME_FORMAT));
+                statement.TryBind("@start_date", range.StartUtc.ToDateTimeParamValue());
+                statement.TryBind("@end_date", range.EndUtc.ToDateTimeParamValue());
 
                 foreach (var row in statement.ExecuteQuery())
                 {
@@ -497,7 +547,7 @@ namespace Jellyfin.Plugin.PlaybackReporting.Data
                         userWatchesByDate = new Dictionary<string, int>();
                         usage.Add(user_id, userWatchesByDate);
                     }
-                    string date_string = DateTime.Parse(row[1].ToString()).Add(userServerTimezoneOffset).ToString("yyyy-MM-dd");
+                    string date_string = TimeZoneHelper.UtcToUserLocal(row[1].ReadDateTime(), userTimezone).ToString("yyyy-MM-dd");
                     int count_int = row[2].ToInt();
                     if (userWatchesByDate.ContainsKey(date_string))
                     {
@@ -514,7 +564,7 @@ namespace Jellyfin.Plugin.PlaybackReporting.Data
             return usage;
         }
 
-        public SortedDictionary<string, int> GetHourlyUsageReport(int days, DateTime endDate, string[] types, float timezoneOffset)
+        public SortedDictionary<string, int> GetHourlyUsageReport(int days, DateTime endDate, string[] types, string timezoneId)
         {
             List<string> filters = new List<string>();
             foreach (string filter in types)
@@ -523,13 +573,12 @@ namespace Jellyfin.Plugin.PlaybackReporting.Data
             }
 
             SortedDictionary<string, int> report_data = new SortedDictionary<string, int>();
-            var userServerTimezoneOffset = CalculateUserServerTimezoneOffset(timezoneOffset);
-            endDate = endDate.Add(userServerTimezoneOffset);
-            DateTime start_date = endDate.Subtract(new TimeSpan(days, 0, 0, 0));
+            var userTimezone = TimeZoneHelper.Resolve(timezoneId, _logger);
+            var range = TimeZoneHelper.GetDateRange(days, endDate, userTimezone);
 
             string sql = "SELECT DateCreated, PlayDuration ";
             sql += "FROM PlaybackActivity ";
-            sql += "WHERE DateCreated >= @start_date AND DateCreated <= @end_date ";
+            sql += "WHERE DateCreated >= @start_date AND DateCreated < @end_date ";
             sql += "AND UserId not IN (select UserId from UserList) ";
             sql += "AND ItemType IN (" + string.Join(",", filters) + ")";
 
@@ -537,31 +586,16 @@ namespace Jellyfin.Plugin.PlaybackReporting.Data
             {
                 using var connection = CreateConnection(true);
                 using var statement = connection.PrepareStatement(sql);
-                statement.TryBind("@start_date", start_date.ToString(DATE_TIME_FORMAT));
-                statement.TryBind("@end_date", endDate.AddDays(1).AddSeconds(-1).ToString(DATE_TIME_FORMAT));
+                statement.TryBind("@start_date", range.StartUtc.ToDateTimeParamValue());
+                statement.TryBind("@end_date", range.EndUtc.ToDateTimeParamValue());
 
                 foreach (var row in statement.ExecuteQuery())
                 {
-                    DateTime date = row[0].ReadDateTime().Add(userServerTimezoneOffset);
+                    DateTime date = row[0].ReadDateTime();
                     int duration = row[1].ToInt();
-
-                    int seconds_left_in_hour = 3600 - (date.Minute * 60 + date.Second);
-                    _logger.LogInformation("Processing - date: {Date} duration: {Duration} seconds_left_in_hour {SecondsLeftInHour}", date, duration, seconds_left_in_hour);
-                    while (duration > 0)
+                    foreach (var segment in TimeZoneHelper.SplitIntoLocalHours(date, duration, userTimezone))
                     {
-                        string hour_id = (int)date.DayOfWeek + "-" + date.ToString("HH");
-                        if (duration > seconds_left_in_hour)
-                        {
-                            AddTimeToHours(report_data, hour_id, seconds_left_in_hour);
-                        }
-                        else
-                        {
-                            AddTimeToHours(report_data, hour_id, duration);
-                        }
-
-                        duration -= seconds_left_in_hour;
-                        seconds_left_in_hour = 3600;
-                        date = date.AddHours(1);
+                        AddTimeToHours(report_data, segment.Key, segment.Seconds);
                     }
                 }
             }
@@ -582,19 +616,18 @@ namespace Jellyfin.Plugin.PlaybackReporting.Data
             }
         }
 
-        public List<Dictionary<string, object>> GetBreakdownReport(int days, DateTime endDate, string type, float timezoneOffset)
+        public List<Dictionary<string, object>> GetBreakdownReport(int days, DateTime endDate, string type, string timezoneId)
         {
             // UserId ItemType PlaybackMethod ClientName DeviceName
 
             List<Dictionary<string, object>> report = new List<Dictionary<string, object>>();
 
-            var userServerTimezoneOffset = CalculateUserServerTimezoneOffset(timezoneOffset);
-            endDate = endDate.Add(userServerTimezoneOffset);
-            DateTime start_date = endDate.Subtract(new TimeSpan(days, 0, 0, 0));
+            var userTimezone = TimeZoneHelper.Resolve(timezoneId, _logger);
+            var range = TimeZoneHelper.GetDateRange(days, endDate, userTimezone);
 
             string sql = "SELECT " + type + ", COUNT(1) AS PlayCount, SUM(PlayDuration) AS Seconds ";
             sql += "FROM PlaybackActivity ";
-            sql += "WHERE DateCreated >= @start_date AND DateCreated <= @end_date ";
+            sql += "WHERE DateCreated >= @start_date AND DateCreated < @end_date ";
             sql += "AND UserId not IN (select UserId from UserList) ";
             sql += "GROUP BY " + type;
 
@@ -602,8 +635,8 @@ namespace Jellyfin.Plugin.PlaybackReporting.Data
             {
                 using var connection = CreateConnection(true);
                 using var statement = connection.PrepareStatement(sql);
-                statement.TryBind("@start_date", start_date.ToString(DATE_TIME_FORMAT));
-                statement.TryBind("@end_date", endDate.AddDays(1).AddSeconds(-1).ToString(DATE_TIME_FORMAT));
+                statement.TryBind("@start_date", range.StartUtc.ToDateTimeParamValue());
+                statement.TryBind("@end_date", range.EndUtc.ToDateTimeParamValue());
 
                 foreach (var row in statement.ExecuteQuery())
                 {
@@ -622,7 +655,7 @@ namespace Jellyfin.Plugin.PlaybackReporting.Data
             return report;
         }
 
-        public SortedDictionary<int, int> GetDurationHistogram(int days, DateTime endDate, string[] types)
+        public SortedDictionary<int, int> GetDurationHistogram(int days, DateTime endDate, string[] types, string timezoneId)
         {
             /*
             SELECT CAST(PlayDuration / 300 as int) AS FiveMinBlock, COUNT(1) ActionCount
@@ -638,12 +671,13 @@ namespace Jellyfin.Plugin.PlaybackReporting.Data
             }
 
             SortedDictionary<int, int> report = new SortedDictionary<int, int>();
-            DateTime start_date = endDate.Subtract(new TimeSpan(days, 0, 0, 0));
+            var userTimezone = TimeZoneHelper.Resolve(timezoneId, _logger);
+            var range = TimeZoneHelper.GetDateRange(days, endDate, userTimezone);
 
             string sql =
                 "SELECT CAST(PlayDuration / 300 as int) AS FiveMinBlock, COUNT(1) ActionCount " +
                 "FROM PlaybackActivity " +
-                "WHERE DateCreated >= @start_date AND DateCreated <= @end_date " +
+                "WHERE DateCreated >= @start_date AND DateCreated < @end_date " +
                 "AND UserId not IN (select UserId from UserList) " +
                 "AND ItemType IN (" + string.Join(",", filters) + ") " +
                 "GROUP BY CAST(PlayDuration / 300 as int) " +
@@ -653,8 +687,8 @@ namespace Jellyfin.Plugin.PlaybackReporting.Data
             {
                 using var connection = CreateConnection(true);
                 using var statement = connection.PrepareStatement(sql);
-                statement.TryBind("@start_date", start_date.ToString("yyyy-MM-dd 00:00:00"));
-                statement.TryBind("@end_date", endDate.ToString("yyyy-MM-dd 23:59:59"));
+                statement.TryBind("@start_date", range.StartUtc.ToDateTimeParamValue());
+                statement.TryBind("@end_date", range.EndUtc.ToDateTimeParamValue());
 
                 foreach (var row in statement.ExecuteQuery())
                 {
@@ -667,13 +701,12 @@ namespace Jellyfin.Plugin.PlaybackReporting.Data
             return report;
         }
 
-        public List<Dictionary<string, object>> GetTvShowReport(int days, DateTime endDate, float timezoneOffset)
+        public List<Dictionary<string, object>> GetTvShowReport(int days, DateTime endDate, string timezoneId)
         {
             List<Dictionary<string, object>> report = new List<Dictionary<string, object>>();
 
-            var userServerTimezoneOffset = CalculateUserServerTimezoneOffset(timezoneOffset);
-            endDate = endDate.Add(userServerTimezoneOffset);
-            DateTime start_date = endDate.Subtract(new TimeSpan(days, 0, 0, 0));
+            var userTimezone = TimeZoneHelper.Resolve(timezoneId, _logger);
+            var range = TimeZoneHelper.GetDateRange(days, endDate, userTimezone);
 
             string sql = "";
             sql += "SELECT substr(ItemName,0, instr(ItemName, ' - ')) AS name, ";
@@ -681,7 +714,7 @@ namespace Jellyfin.Plugin.PlaybackReporting.Data
             sql += "SUM(PlayDuration) AS total_duarion ";
             sql += "FROM PlaybackActivity ";
             sql += "WHERE ItemType = 'Episode' ";
-            sql += "AND DateCreated >= @start_date AND DateCreated <= @end_date ";
+            sql += "AND DateCreated >= @start_date AND DateCreated < @end_date ";
             sql += "AND UserId not IN (select UserId from UserList) ";
             sql += "GROUP BY name";
 
@@ -689,8 +722,8 @@ namespace Jellyfin.Plugin.PlaybackReporting.Data
             {
                 using var connection = CreateConnection(true);
                 using var statement = connection.PrepareStatement(sql);
-                statement.TryBind("@start_date", start_date.ToString(DATE_TIME_FORMAT));
-                statement.TryBind("@end_date", endDate.AddDays(1).AddSeconds(-1).ToString(DATE_TIME_FORMAT));
+                statement.TryBind("@start_date", range.StartUtc.ToDateTimeParamValue());
+                statement.TryBind("@end_date", range.EndUtc.ToDateTimeParamValue());
 
                 foreach (var row in statement.ExecuteQuery())
                 {
@@ -711,13 +744,12 @@ namespace Jellyfin.Plugin.PlaybackReporting.Data
             return report;
         }
 
-        public List<Dictionary<string, object>> GetMoviesReport(int days, DateTime endDate, float timezoneOffset)
+        public List<Dictionary<string, object>> GetMoviesReport(int days, DateTime endDate, string timezoneId)
         {
             List<Dictionary<string, object>> report = new List<Dictionary<string, object>>();
 
-            var userServerTimezoneOffset = CalculateUserServerTimezoneOffset(timezoneOffset);
-            endDate = endDate.Add(userServerTimezoneOffset);
-            DateTime start_date = endDate.Subtract(new TimeSpan(days, 0, 0, 0));
+            var userTimezone = TimeZoneHelper.Resolve(timezoneId, _logger);
+            var range = TimeZoneHelper.GetDateRange(days, endDate, userTimezone);
 
             string sql = "";
             sql += "SELECT ItemName AS name, ";
@@ -725,7 +757,7 @@ namespace Jellyfin.Plugin.PlaybackReporting.Data
             sql += "SUM(PlayDuration) AS total_duarion ";
             sql += "FROM PlaybackActivity ";
             sql += "WHERE ItemType = 'Movie' ";
-            sql += "AND DateCreated >= @start_date AND DateCreated <= @end_date ";
+            sql += "AND DateCreated >= @start_date AND DateCreated < @end_date ";
             sql += "AND UserId not IN (select UserId from UserList) ";
             sql += "GROUP BY name";
 
@@ -733,8 +765,8 @@ namespace Jellyfin.Plugin.PlaybackReporting.Data
             {
                 using var connection = CreateConnection(true);
                 using var statement = connection.PrepareStatement(sql);
-                statement.TryBind("@start_date", start_date.ToString(DATE_TIME_FORMAT));
-                statement.TryBind("@end_date", endDate.AddDays(1).AddSeconds(-1).ToString(DATE_TIME_FORMAT));
+                statement.TryBind("@start_date", range.StartUtc.ToDateTimeParamValue());
+                statement.TryBind("@end_date", range.EndUtc.ToDateTimeParamValue());
 
                 foreach (var row in statement.ExecuteQuery())
                 {
@@ -753,20 +785,19 @@ namespace Jellyfin.Plugin.PlaybackReporting.Data
             return report;
         }
 
-        public List<Dictionary<string, object>> GetUserReport(int days, DateTime endDate, float timezoneOffset)
+        public List<Dictionary<string, object>> GetUserReport(int days, DateTime endDate, string timezoneId)
         {
             List<Dictionary<string, object>> report = new List<Dictionary<string, object>>();
 
-            var userServerTimezoneOffset = CalculateUserServerTimezoneOffset(timezoneOffset);
-            endDate = endDate.Add(userServerTimezoneOffset);
-            DateTime start_date = endDate.Subtract(new TimeSpan(days, 0, 0, 0));
+            var userTimezone = TimeZoneHelper.Resolve(timezoneId, _logger);
+            var range = TimeZoneHelper.GetDateRange(days, endDate, userTimezone);
 
             string sql = "";
             sql += "SELECT x.latest_date, x.UserId, x.play_count, x.total_duarion, y.ItemName, y.DeviceName ";
             sql += "FROM( ";
             sql += "SELECT MAX(DateCreated) AS latest_date, UserId, COUNT(1) AS play_count, SUM(PlayDuration) AS total_duarion ";
             sql += "FROM PlaybackActivity ";
-            sql += "WHERE DateCreated >= @start_date AND DateCreated <= @end_date ";
+            sql += "WHERE DateCreated >= @start_date AND DateCreated < @end_date ";
             sql += "AND UserId not IN (select UserId from UserList) ";
             sql += "GROUP BY UserId ";
             sql += ") AS x ";
@@ -777,14 +808,14 @@ namespace Jellyfin.Plugin.PlaybackReporting.Data
             {
                 using var connection = CreateConnection(true);
                 using var statement = connection.PrepareStatement(sql);
-                statement.TryBind("@start_date", start_date.ToString(DATE_TIME_FORMAT));
-                statement.TryBind("@end_date", endDate.AddDays(1).AddSeconds(-1).ToString(DATE_TIME_FORMAT));
+                statement.TryBind("@start_date", range.StartUtc.ToDateTimeParamValue());
+                statement.TryBind("@end_date", range.EndUtc.ToDateTimeParamValue());
 
                 foreach (var row in statement.ExecuteQuery())
                 {
                     Dictionary<string, object> row_data = new Dictionary<string, object>();
 
-                    DateTime latest_date = row[0].ReadDateTime().Add(userServerTimezoneOffset);
+                    DateTime latest_date = row[0].ReadDateTime();
                     row_data.Add("latest_date", latest_date);
 
                     string user_id = row[1].ToString();

--- a/Jellyfin.Plugin.PlaybackReporting/Data/IActivityRepository.cs
+++ b/Jellyfin.Plugin.PlaybackReporting/Data/IActivityRepository.cs
@@ -21,6 +21,7 @@ namespace Jellyfin.Plugin.PlaybackReporting.Data
 {
     public interface IActivityRepository : IDisposable
     {
+        void Initialize();
         int RemoveUnknownUsers(List<string> known_user_ids);
         void ManageUserList(string action, string id);
         List<string> GetUserList();
@@ -30,14 +31,14 @@ namespace Jellyfin.Plugin.PlaybackReporting.Data
         void DeleteOldData(DateTime? del_before);
         void AddPlaybackAction(PlaybackInfo play_info);
         void UpdatePlaybackAction(PlaybackInfo play_info);
-        List<Dictionary<string, string>> GetUsageForUser(string date, string user_id, string[] filter, float timezoneOffset);
-        Dictionary<String, Dictionary<string, int>> GetUsageForDays(int days, DateTime end_date, string[] types, string? data_type, float timezoneOffset);
-        SortedDictionary<string, int> GetHourlyUsageReport(int days, DateTime end_date, string[] types, float timezoneOffset);
-        List<Dictionary<string, object>> GetBreakdownReport(int days, DateTime end_date, string type, float timezoneOffset);
-        SortedDictionary<int, int> GetDurationHistogram(int days, DateTime end_date, string[] types);
-        List<Dictionary<string, object>> GetTvShowReport(int days, DateTime end_date, float timezoneOffset);
-        List<Dictionary<string, object>> GetMoviesReport(int days, DateTime end_date, float timezoneOffset);
-        List<Dictionary<string, object>> GetUserReport(int days, DateTime end_date, float timezoneOffset);
+        List<Dictionary<string, string>> GetUsageForUser(string date, string user_id, string[] filter, string timezoneId);
+        Dictionary<String, Dictionary<string, int>> GetUsageForDays(int days, DateTime end_date, string[] types, string? data_type, string timezoneId);
+        SortedDictionary<string, int> GetHourlyUsageReport(int days, DateTime end_date, string[] types, string timezoneId);
+        List<Dictionary<string, object>> GetBreakdownReport(int days, DateTime end_date, string type, string timezoneId);
+        SortedDictionary<int, int> GetDurationHistogram(int days, DateTime end_date, string[] types, string timezoneId);
+        List<Dictionary<string, object>> GetTvShowReport(int days, DateTime end_date, string timezoneId);
+        List<Dictionary<string, object>> GetMoviesReport(int days, DateTime end_date, string timezoneId);
+        List<Dictionary<string, object>> GetUserReport(int days, DateTime end_date, string timezoneId);
         string RunCustomQuery(string query_string, List<string> col_names, List<List<object>> results);
     }
 }

--- a/Jellyfin.Plugin.PlaybackReporting/Data/SqliteExtensions.cs
+++ b/Jellyfin.Plugin.PlaybackReporting/Data/SqliteExtensions.cs
@@ -87,12 +87,55 @@ namespace Jellyfin.Plugin.PlaybackReporting.Data
 
         public static DateTime ReadDateTime(this ResultSetValue result)
         {
-            var dateText = result.ToString();
+            return result.ToString().ParseDateTimeToUtc();
+        }
 
-            return DateTime.ParseExact(
+        public static DateTime ParseDateTimeToUtc(this string dateText, TimeZoneInfo? legacyTimezone = null)
+        {
+            DateTime parsed = DateTime.ParseExact(
                 dateText, _datetimeFormats,
                 DateTimeFormatInfo.InvariantInfo,
-                DateTimeStyles.None).ToUniversalTime();
+                DateTimeStyles.None);
+            if (parsed.Kind == DateTimeKind.Utc || dateText.EndsWith("Z", StringComparison.OrdinalIgnoreCase) || HasExplicitOffset(dateText))
+            {
+                return DateTimeOffset.ParseExact(dateText, _datetimeFormats, DateTimeFormatInfo.InvariantInfo, DateTimeStyles.None).UtcDateTime;
+            }
+
+            return TimeZoneInfo.ConvertTimeToUtc(DateTime.SpecifyKind(parsed, DateTimeKind.Unspecified), legacyTimezone ?? TimeZoneInfo.Utc);
+        }
+
+        private static bool HasExplicitOffset(string text)
+        {
+            // A '+' or '-' inside the first 10 characters is a date separator ("yyyy-MM-dd");
+            // later in the string it only counts as an explicit UTC offset when the remaining
+            // tail is shaped like one ("+HH", "+HHmm", "+HH:mm").
+            int separator = text.LastIndexOfAny(new[] { '+', '-' });
+            if (separator < 10)
+            {
+                return false;
+            }
+
+            string tail = text.Substring(separator + 1);
+            return (tail.Length == 5 && tail[2] == ':') || tail.Length == 4 || tail.Length == 2;
+        }
+
+        public static DateTime TruncateToSeconds(this DateTime dateValue)
+        {
+            return new DateTime(
+                dateValue.Ticks - (dateValue.Ticks % TimeSpan.TicksPerSecond),
+                dateValue.Kind);
+        }
+
+        /// <summary>
+        /// Formats a DateTime for the PlaybackActivity DateCreated column: converted to UTC and
+        /// truncated to whole seconds, always producing the fixed-width "yyyy-MM-dd HH:mm:ssZ" shape.
+        /// DateCreated values are stored and compared as TEXT by SQLite, so every value must share
+        /// this exact shape: a fractional-seconds value would sort before a whole-seconds value
+        /// ('.' sorts before 'Z') and break the >= / < comparisons.
+        /// </summary>
+        public static string ToUtcDateParamValue(this DateTime dateValue)
+        {
+            return dateValue.ToUniversalTime().TruncateToSeconds().ToDateTimeParamValue();
         }
 
         private static void CheckName(string name)

--- a/Jellyfin.Plugin.PlaybackReporting/Data/TimeZoneHelper.cs
+++ b/Jellyfin.Plugin.PlaybackReporting/Data/TimeZoneHelper.cs
@@ -1,0 +1,150 @@
+/*
+Copyright(C) 2026
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see<http://www.gnu.org/licenses/>.
+*/
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using Microsoft.Extensions.Logging;
+
+namespace Jellyfin.Plugin.PlaybackReporting.Data
+{
+    public static class TimeZoneHelper
+    {
+        public readonly record struct DateRange(DateTime StartUtc, DateTime EndUtc);
+        private const int MaxCacheSize = 256;
+        private static readonly ConcurrentDictionary<string, TimeZoneInfo> _timezoneCache = new(StringComparer.Ordinal);
+        private static readonly ConcurrentDictionary<string, byte> _warnedTimezoneIds = new(StringComparer.Ordinal);
+
+        public static TimeZoneInfo Resolve(string timezoneId, ILogger logger)
+        {
+            if (_timezoneCache.TryGetValue(timezoneId, out TimeZoneInfo? cached))
+            {
+                return cached;
+            }
+
+            TimeZoneInfo timezone;
+            try
+            {
+                timezone = TimeZoneInfo.FindSystemTimeZoneById(timezoneId);
+            }
+            catch (TimeZoneNotFoundException)
+            {
+                if (_warnedTimezoneIds.TryAdd(timezoneId, 0))
+                {
+                    logger.LogWarning("Unknown timezone '{TimezoneId}', falling back to UTC", timezoneId);
+                }
+
+                return TimeZoneInfo.Utc;
+            }
+            catch (InvalidTimeZoneException)
+            {
+                if (_warnedTimezoneIds.TryAdd(timezoneId, 0))
+                {
+                    logger.LogWarning("Invalid timezone '{TimezoneId}', falling back to UTC", timezoneId);
+                }
+
+                return TimeZoneInfo.Utc;
+            }
+
+            if (_timezoneCache.Count < MaxCacheSize)
+            {
+                _timezoneCache.TryAdd(timezoneId, timezone);
+            }
+
+            return timezone;
+        }
+
+        public static DateTime UtcToUserLocal(DateTime utcTime, TimeZoneInfo timezone)
+        {
+            return TimeZoneInfo.ConvertTimeFromUtc(utcTime, timezone);
+        }
+
+        public static DateTime UserLocalToUtc(DateTime userLocal, TimeZoneInfo timezone)
+        {
+            DateTime unspecified = DateTime.SpecifyKind(userLocal, DateTimeKind.Unspecified);
+            while (timezone.IsInvalidTime(unspecified))
+            {
+                unspecified = unspecified.AddMinutes(1);
+            }
+
+            if (!timezone.IsAmbiguousTime(unspecified))
+            {
+                return TimeZoneInfo.ConvertTimeToUtc(unspecified, timezone);
+            }
+
+            DateTime[] candidates = Array.ConvertAll(timezone.GetAmbiguousTimeOffsets(unspecified), offset =>
+                DateTime.SpecifyKind(unspecified - offset, DateTimeKind.Utc));
+            Array.Sort(candidates);
+            return candidates[0];
+        }
+
+        public static DateRange GetDateRange(int days, DateTime endDate, TimeZoneInfo timezone)
+        {
+            DateTime localStart = endDate.Date.AddDays(1 - days);
+            DateTime localEnd = endDate.Date.AddDays(1);
+            return new DateRange(UserLocalToUtc(localStart, timezone), UserLocalToUtc(localEnd, timezone));
+        }
+
+        public static IEnumerable<(string Key, int Seconds)> SplitIntoLocalHours(DateTime startUtc, int duration, TimeZoneInfo timezone)
+        {
+            DateTime current = DateTime.SpecifyKind(startUtc, DateTimeKind.Utc);
+            DateTime end = current.AddSeconds(duration);
+            while (current < end)
+            {
+                DateTime local = UtcToUserLocal(current, timezone);
+                DateTime next = GetNextLocalHourBoundaryUtc(current, local, timezone);
+                if (next <= current || next > end)
+                {
+                    next = end;
+                }
+
+                yield return ($"{(int)local.DayOfWeek}-{local:HH}", (int)(next - current).TotalSeconds);
+                current = next;
+            }
+        }
+
+        private static DateTime GetNextLocalHourBoundaryUtc(DateTime currentUtc, DateTime local, TimeZoneInfo timezone)
+        {
+            DateTime boundary = new DateTime(local.Year, local.Month, local.Day, local.Hour, 0, 0, DateTimeKind.Unspecified).AddHours(1);
+            while (true)
+            {
+                if (timezone.IsInvalidTime(boundary))
+                {
+                    boundary = boundary.AddHours(1);
+                    continue;
+                }
+
+                if (!timezone.IsAmbiguousTime(boundary))
+                {
+                    return UserLocalToUtc(boundary, timezone);
+                }
+
+                DateTime[] candidates = Array.ConvertAll(timezone.GetAmbiguousTimeOffsets(boundary), offset =>
+                    DateTime.SpecifyKind(boundary - offset, DateTimeKind.Utc));
+                Array.Sort(candidates);
+                foreach (DateTime candidate in candidates)
+                {
+                    if (candidate > currentUtc)
+                    {
+                        return candidate;
+                    }
+                }
+
+                boundary = boundary.AddHours(1);
+            }
+        }
+    }
+}

--- a/Jellyfin.Plugin.PlaybackReporting/EventMonitorEntryPoint.cs
+++ b/Jellyfin.Plugin.PlaybackReporting/EventMonitorEntryPoint.cs
@@ -248,7 +248,7 @@ namespace Jellyfin.Plugin.PlaybackReporting
 
                     PlaybackInfo play_info = new PlaybackInfo(
                         id: Guid.NewGuid().ToString("N"),
-                        date: DateTime.Now,
+                        date: DateTime.UtcNow,
                         clientName: e.ClientName,
                         deviceName: e.DeviceName,
                         playbackMethod: play_method,

--- a/Jellyfin.Plugin.PlaybackReporting/Pages/breakdown_report.js
+++ b/Jellyfin.Plugin.PlaybackReporting/Pages/breakdown_report.js
@@ -273,10 +273,10 @@ const getConfigurationPageUrl = (name) => {
                     //Set days filter to 50 years if 'all' option is selected.
                     if (days == -7) days = 18250;
 
-                    const timezoneOffset = -(new Date().getTimezoneOffset() / 60);
+                    const timezoneId = Intl.DateTimeFormat().resolvedOptions().timeZone;
 
                     // build user chart
-                    var url = "user_usage_stats/UserId/BreakdownReport?days=" + days + "&endDate=" + end_date.value + "&stamp=" + new Date().getTime() + "&timezoneOffset=" + timezoneOffset;
+                    var url = "user_usage_stats/UserId/BreakdownReport?days=" + days + "&endDate=" + end_date.value + "&stamp=" + new Date().getTime() + "&timezoneId=" + encodeURIComponent(timezoneId);
                     url = window.ApiClient.getUrl(url);
                     window.ApiClient.getUserActivity(url).then(function (data) {
                         //alert("Loaded Data: " + JSON.stringify(usage_data));
@@ -284,7 +284,7 @@ const getConfigurationPageUrl = (name) => {
                     });
 
                     // build ItemType chart
-                    var url = "user_usage_stats/ItemType/BreakdownReport?days=" + days + "&endDate=" + end_date.value + "&stamp=" + new Date().getTime() + "&timezoneOffset=" + timezoneOffset;
+                    var url = "user_usage_stats/ItemType/BreakdownReport?days=" + days + "&endDate=" + end_date.value + "&stamp=" + new Date().getTime() + "&timezoneId=" + encodeURIComponent(timezoneId);
                     url = window.ApiClient.getUrl(url);
                     window.ApiClient.getUserActivity(url).then(function (data) {
                         //alert("Loaded Data: " + JSON.stringify(usage_data));
@@ -292,7 +292,7 @@ const getConfigurationPageUrl = (name) => {
                     });
 
                     // build PlaybackMethod chart
-                    var url = "user_usage_stats/PlaybackMethod/BreakdownReport?days=" + days + "&endDate=" + end_date.value + "&stamp=" + new Date().getTime() + "&timezoneOffset=" + timezoneOffset;
+                    var url = "user_usage_stats/PlaybackMethod/BreakdownReport?days=" + days + "&endDate=" + end_date.value + "&stamp=" + new Date().getTime() + "&timezoneId=" + encodeURIComponent(timezoneId);
                     url = window.ApiClient.getUrl(url);
                     window.ApiClient.getUserActivity(url).then(function (data) {
                         //alert("Loaded Data: " + JSON.stringify(usage_data));
@@ -300,7 +300,7 @@ const getConfigurationPageUrl = (name) => {
                     });
 
                     // build ClientName chart
-                    var url = "user_usage_stats/ClientName/BreakdownReport?days=" + days + "&endDate=" + end_date.value + "&stamp=" + new Date().getTime() + "&timezoneOffset=" + timezoneOffset;
+                    var url = "user_usage_stats/ClientName/BreakdownReport?days=" + days + "&endDate=" + end_date.value + "&stamp=" + new Date().getTime() + "&timezoneId=" + encodeURIComponent(timezoneId);
                     url = window.ApiClient.getUrl(url);
                     window.ApiClient.getUserActivity(url).then(function (data) {
                         //alert("Loaded Data: " + JSON.stringify(usage_data));
@@ -308,7 +308,7 @@ const getConfigurationPageUrl = (name) => {
                     });
 
                     // build DeviceName chart
-                    var url = "user_usage_stats/DeviceName/BreakdownReport?days=" + days + "&endDate=" + end_date.value + "&stamp=" + new Date().getTime() + "&timezoneOffset=" + timezoneOffset;
+                    var url = "user_usage_stats/DeviceName/BreakdownReport?days=" + days + "&endDate=" + end_date.value + "&stamp=" + new Date().getTime() + "&timezoneId=" + encodeURIComponent(timezoneId);
                     url = window.ApiClient.getUrl(url);
                     window.ApiClient.getUserActivity(url).then(function (data) {
                         //alert("Loaded Data: " + JSON.stringify(usage_data));
@@ -316,7 +316,7 @@ const getConfigurationPageUrl = (name) => {
                     });
 
                     // build TvShows chart
-                    var url = "user_usage_stats/GetTvShowsReport?days=" + days + "&endDate=" + end_date.value + "&stamp=" + new Date().getTime() + "&timezoneOffset=" + timezoneOffset;
+                    var url = "user_usage_stats/GetTvShowsReport?days=" + days + "&endDate=" + end_date.value + "&stamp=" + new Date().getTime() + "&timezoneId=" + encodeURIComponent(timezoneId);
                     url = window.ApiClient.getUrl(url);
                     window.ApiClient.getUserActivity(url).then(function (data) {
                         //alert("Loaded Data: " + JSON.stringify(usage_data));
@@ -324,7 +324,7 @@ const getConfigurationPageUrl = (name) => {
                     });
 
                     // build Movies chart
-                    var url = "user_usage_stats/MoviesReport?days=" + days + "&endDate=" + end_date.value + "&stamp=" + new Date().getTime() + "&timezoneOffset=" + timezoneOffset;
+                    var url = "user_usage_stats/MoviesReport?days=" + days + "&endDate=" + end_date.value + "&stamp=" + new Date().getTime() + "&timezoneId=" + encodeURIComponent(timezoneId);
                     url = window.ApiClient.getUrl(url);
                     window.ApiClient.getUserActivity(url).then(function (data) {
                         //alert("Loaded Data: " + JSON.stringify(usage_data));

--- a/Jellyfin.Plugin.PlaybackReporting/Pages/duration_histogram_report.js
+++ b/Jellyfin.Plugin.PlaybackReporting/Pages/duration_histogram_report.js
@@ -209,7 +209,7 @@ const getConfigurationPageUrl = (name) => {
                         //Set days filter to 50 years if 'all' option is selected.
                         if (days == -7) days = 18250;
 
-                        var url = "user_usage_stats/DurationHistogramReport?days=" + days + "&endDate=" + end_date.value + "&filter=" + filter.join(",") + "&stamp=" + new Date().getTime();
+                        var url = "user_usage_stats/DurationHistogramReport?days=" + days + "&endDate=" + end_date.value + "&filter=" + filter.join(",") + "&stamp=" + new Date().getTime() + "&timezoneId=" + encodeURIComponent(Intl.DateTimeFormat().resolvedOptions().timeZone);
                         url = window.ApiClient.getUrl(url);
                         window.ApiClient.getUserActivity(url).then(function (usage_data) {
                             //alert("Loaded Data: " + JSON.stringify(usage_data));

--- a/Jellyfin.Plugin.PlaybackReporting/Pages/hourly_usage_report.js
+++ b/Jellyfin.Plugin.PlaybackReporting/Pages/hourly_usage_report.js
@@ -411,8 +411,8 @@ const getConfigurationPageUrl = (name) => {
                         //Set days filter to 50 years if 'all' option is selected.
                         if (days == -7) days = 18250;
 
-                        const timezoneOffset = -(new Date().getTimezoneOffset() / 60);
-                        var url = "user_usage_stats/HourlyReport?days=" + days + "&endDate=" + end_date.value + "&filter=" + filter.join(",") + "&stamp=" + new Date().getTime() + "&timezoneOffset=" + timezoneOffset;
+                        const timezoneId = Intl.DateTimeFormat().resolvedOptions().timeZone;
+                        var url = "user_usage_stats/HourlyReport?days=" + days + "&endDate=" + end_date.value + "&filter=" + filter.join(",") + "&stamp=" + new Date().getTime() + "&timezoneId=" + encodeURIComponent(timezoneId);
                         url = window.ApiClient.getUrl(url);
                         window.ApiClient.getUserActivity(url).then(function (usage_data) {
                             //alert("Loaded Data: " + JSON.stringify(usage_data));

--- a/Jellyfin.Plugin.PlaybackReporting/Pages/user_playback_report.js
+++ b/Jellyfin.Plugin.PlaybackReporting/Pages/user_playback_report.js
@@ -266,8 +266,8 @@ const getConfigurationPageUrl = (name) => {
             }
         }
 
-        const tzOffset = -(new Date().getTimezoneOffset() / 60);
-        var url_to_get = "user_usage_stats/" + user_id + "/" + data_label + "/GetItems?filter=" + filter.join(",") + "&stamp=" + new Date().getTime() + "&timezoneOffset=" + tzOffset;
+        const timezoneId = Intl.DateTimeFormat().resolvedOptions().timeZone;
+        var url_to_get = "user_usage_stats/" + user_id + "/" + data_label + "/GetItems?filter=" + filter.join(",") + "&stamp=" + new Date().getTime() + "&timezoneId=" + encodeURIComponent(timezoneId);
         url_to_get = window.ApiClient.getUrl(url_to_get);
         console.log("User Report Details Url: " + url_to_get);
 
@@ -491,8 +491,8 @@ const getConfigurationPageUrl = (name) => {
                     weeks.addEventListener("change", process_click);
                     var days = parseInt(weeks.value) * 7;
 
-                    const tzOffset = -(new Date().getTimezoneOffset() / 60);
-                    var url = "user_usage_stats/PlayActivity?filter=" + filter_names.join(",") + "&days=" + days + "&endDate=" + end_date.value + "&dataType=count&stamp=" + new Date().getTime() + "&timezoneOffset=" + tzOffset;
+                    const timezoneId = Intl.DateTimeFormat().resolvedOptions().timeZone;
+                    var url = "user_usage_stats/PlayActivity?filter=" + filter_names.join(",") + "&days=" + days + "&endDate=" + end_date.value + "&dataType=count&stamp=" + new Date().getTime() + "&timezoneId=" + encodeURIComponent(timezoneId);
                     url = window.ApiClient.getUrl(url);
                     window.ApiClient.getUserActivity(url).then(function (usage_data) {
                         //alert("Loaded Data: " + JSON.stringify(usage_data));
@@ -518,8 +518,8 @@ const getConfigurationPageUrl = (name) => {
                         days = parseInt(weeks.value) * 7;
 
 
-                        const tzOffset = -(new Date().getTimezoneOffset() / 60);
-                        var filtered_url = "user_usage_stats/PlayActivity?filter=" + filter.join(",") + "&days=" + days + "&endDate=" + end_date.value + "&dataType=" + data_t + "&stamp=" + new Date().getTime() + "&timezoneOffset=" + tzOffset;
+                        const timezoneId = Intl.DateTimeFormat().resolvedOptions().timeZone;
+                        var filtered_url = "user_usage_stats/PlayActivity?filter=" + filter.join(",") + "&days=" + days + "&endDate=" + end_date.value + "&dataType=" + data_t + "&stamp=" + new Date().getTime() + "&timezoneId=" + encodeURIComponent(timezoneId);
                         filtered_url = window.ApiClient.getUrl(filtered_url);
                         window.ApiClient.getUserActivity(filtered_url).then(function (usage_data) {
                             draw_graph(view, d3, usage_data);

--- a/Jellyfin.Plugin.PlaybackReporting/Pages/user_report.js
+++ b/Jellyfin.Plugin.PlaybackReporting/Pages/user_report.js
@@ -87,7 +87,8 @@ const getConfigurationPageUrl = (name) => {
                 //Set days filter to 50 years if 'all' option is selected.
                 if (days == -7) days = 18250;
 
-                var url = "user_usage_stats/user_activity?days=" + days + "&endDate=" + end_date.value + "&stamp=" + new Date().getTime();
+                const timezoneId = Intl.DateTimeFormat().resolvedOptions().timeZone;
+                var url = "user_usage_stats/user_activity?days=" + days + "&endDate=" + end_date.value + "&timezoneId=" + encodeURIComponent(timezoneId) + "&stamp=" + new Date().getTime();
                 url = window.ApiClient.getUrl(url);
                 window.ApiClient.getUserActivity(url).then(function (user_data) {
                     console.log("usage_data: " + JSON.stringify(user_data));

--- a/Jellyfin.Plugin.PlaybackReporting/TaskCleanDb.cs
+++ b/Jellyfin.Plugin.PlaybackReporting/TaskCleanDb.cs
@@ -49,7 +49,7 @@ namespace Jellyfin.Plugin.PlaybackReporting
 
             _logger.LogInformation("TaskCleanDb Loaded");
             var repo = new ActivityRepository(loggerFactory.CreateLogger<ActivityRepository>(), _config.ApplicationPaths, _fileSystem);
-            //repo.Initialize();
+            repo.Initialize();
             Repository = repo;
         }
 
@@ -88,7 +88,7 @@ namespace Jellyfin.Plugin.PlaybackReporting
                 }
                 else
                 {
-                    DateTime del_defore = DateTime.Now.AddMonths(max_data_age * -1);
+                    DateTime del_defore = DateTime.UtcNow.AddMonths(max_data_age * -1);
                     Repository.DeleteOldData(del_defore);
                 }
             }, cancellationToken);


### PR DESCRIPTION
This PR migrates the database to convert the timezoneless datetimes in the database (based on the server's local timezone) to be stored as UTC datetimes. It also replaces all the timezone offset logic with passing timezone ids instead. This addresses issues caused by applying the offset incorrectly (https://github.com/jellyfin/jellyfin-plugin-playbackreporting/issues/106) as well as handling daylight savings time correctly.

AI use disclosure:
I used AI coding tools to help with these changes; especially finding and replacing all the instances of the time offsets. In accordance with the Jellyfin LLM policy (https://jellyfin.org/docs/general/contributing/llm-policies/#llm-code-contributions-to-official-projects), I've manually reviewed, tested, and am responsible for all the code changes in this PR.

resolves https://github.com/jellyfin/jellyfin-plugin-playbackreporting/issues/106